### PR TITLE
feat(provisioner): provisioner server implementation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,10 @@ run:
   # Include test files.
   tests: true
 
+  # List of build tags to pass to all linters.
+  build-tags:
+    - integration
+
 issues:
   # Set to 0 to not skip any issues.
   max-issues-per-linter: 0

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The Linode COSI Driver is an implementation of the Kubernetes Container Object S
 
 - [Linode COSI Driver](#linode-cosi-driver)
   - [Getting Started](#getting-started)
+  - [Testing](#testing)
+    - [Integration tests](#integration-tests)
+      - [Prerequisites](#prerequisites)
+      - [Test Execution](#test-execution)
+      - [Configuration](#configuration)
+      - [Test Cases](#test-cases)
+        - [Happy Path Test](#happy-path-test)
+      - [Suite Structure](#suite-structure)
   - [License](#license)
   - [Support](#support)
   - [Contributing](#contributing)
@@ -42,6 +50,47 @@ Follow these steps to get started with Linode COSI Driver:
 
 3. **Usage:**
     <!-- TODO: write usage examples -->
+
+## Testing
+
+### Integration tests
+
+#### Prerequisites
+
+Before running the integration tests, ensure the following prerequisites are met:
+
+- **Linode Account**: You need a valid Linode account with access to the Linode API.
+- **Linode Token**: Set the `LINODE_TOKEN` environment variable with your Linode API token.
+- **Environment Variables**: Additional environment variables, such as `LINODE_API_URL` and `LINODE_API_VERSION`, can be set as needed.
+
+#### Test Execution
+
+To run the integration tests, execute the following:
+
+```bash
+go test -tags=integration ./...
+```
+
+The tests cover various operations such as creating a bucket, granting and revoking bucket access, and deleting a bucket. These operations are performed multiple times to ensure idempotency.
+
+#### Configuration
+
+The test suite provides configurable parameters through environment variables:
+
+- `LINODE_TOKEN`: Linode API token.
+- `LINODE_API_URL`: Linode API URL.
+- `LINODE_API_VERSION`: Linode API version.
+- `IDEMPOTENCY_ITERATIONS`: Number of times to run idempotent operations (default is 2).
+
+#### Test Cases
+
+##### Happy Path Test
+
+The `TestHappyPath` function executes a series of idempotent operations on the Linode COSI driver, covering bucket creation, access granting and revoking, and bucket deletion. The test validates the driver's functionality under normal conditions.
+
+#### Suite Structure
+
+The test suite is organized into a `suite` struct, providing a clean separation of concerns for different test operations. The suite includes methods for creating, deleting, granting access to, and revoking access from a bucket. These methods are called in an idempotent loop to ensure the driver's robustness.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,43 @@ Follow these steps to get started with Linode COSI Driver:
     ```
 
 3. **Usage:**
-    <!-- TODO: write usage examples -->
+    1. Create Bucket Class (see the [example.BucketClass.yaml](./examples/example.BucketClass.yaml)).
+    ```sh
+    kubectl create -f ./examples/example.BucketClass.yaml
+    ```
+
+    2. Create Bucket Access Class (see the [example.BucketAccessClass.yaml](./examples/example.BucketAccessClass.yaml)).
+    ```sh
+    kubectl create -f ./examples/example.BucketAccessClass.yaml
+    ```
+
+    3. Create Bucket Claim (see the [example.BucketClaim.yaml](./examples/example.BucketClaim.yaml)).
+    ```sh
+    kubectl create -f ./examples/example.BucketClaim.yaml
+    ```
+
+    4. Create Bucket Access Class (see the [example.BucketAccess.yaml](./examples/example.BucketAccess.yaml)).
+    ```sh
+    kubectl create -f ./examples/example.BucketAccess.yaml
+    ```
+
+    5. Use the `example-secret` secret in your workload, e.g. in deployment:
+    ```yaml
+    spec:
+      template:
+        spec:
+          containers:
+            - volumeMounts:
+                - mountPath: /conf
+                  name: BucketInfo
+          volumes:
+            - name: example-secret-vol
+              secret:
+                name: example-secret
+                items:
+                  - key: BucketInfo
+                    path: BucketInfo.json
+    ```
 
 ## Testing
 

--- a/examples/example.BucketAccessClass.yaml
+++ b/examples/example.BucketAccessClass.yaml
@@ -5,4 +5,5 @@ metadata:
 driverName: objectstorage.cosi.linode.com
 authenticationType: Key
 parameters:
-  permissions: Full # ReadOnly
+  cosi.linode.com/v1/permissions: read_only
+

--- a/examples/example.BucketClass.yaml
+++ b/examples/example.BucketClass.yaml
@@ -5,6 +5,6 @@ metadata:
 driverName: objectstorage.cosi.linode.com
 deletionPolicy: Delete
 parameters:
-  cosi.linode.com/v1/region: us-east
+  cosi.linode.com/v1/region: us-east-1
   cosi.linode.com/v1/acl: private
   cosi.linode.com/v1/cors: disabled

--- a/examples/example.BucketClass.yaml
+++ b/examples/example.BucketClass.yaml
@@ -5,4 +5,6 @@ metadata:
 driverName: objectstorage.cosi.linode.com
 deletionPolicy: Delete
 parameters:
-  region: us-east
+  cosi.linode.com/v1/region: us-east
+  cosi.linode.com/v1/acl: private
+  cosi.linode.com/v1/cors: disabled

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231127180814-3a041ad873d4 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
+	go.opentelemetry.io/otel/metric v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/sdk/metric v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
@@ -26,7 +27,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect
-	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231127180814-3a041ad873d4 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/helm/linode-cosi-driver/templates/Secret.yaml
+++ b/helm/linode-cosi-driver/templates/Secret.yaml
@@ -13,10 +13,10 @@ metadata:
 type: Opaque
 data:
   LINODE_TOKEN: {{ required "value 'apiToken' required" .Values.apiToken | b64enc }}
-  {{- if .Values.linodeApiUrl -}}
+  {{- if .Values.linodeApiUrl }}
   LINODE_API_URL: {{ .Values.linodeApiUrl | b64enc }}
   {{- end }}
-  {{- if .Values.linodeApiVersion -}}
+  {{- if .Values.linodeApiVersion }}
   LINODE_API_VERSION: {{ .Values.linodeApiVersion | b64enc }}
   {{- end }}
 {{- end }}

--- a/pkg/envflag/envflag.go
+++ b/pkg/envflag/envflag.go
@@ -50,3 +50,16 @@ func Bool(envKey string, defaultValue bool) bool {
 
 	return defaultValue
 }
+
+func Int(envKey string, defaultValue int) int {
+	val, ok := os.LookupEnv(envKey)
+	if !ok {
+		return defaultValue
+	}
+
+	if actual, err := strconv.Atoi(val); err == nil {
+		return actual
+	}
+
+	return defaultValue
+}

--- a/pkg/envflag/envflag_test.go
+++ b/pkg/envflag/envflag_test.go
@@ -211,3 +211,51 @@ func TestBool(t *testing.T) {
 		})
 	}
 }
+
+//nolint:paralleltest
+func TestInts(t *testing.T) {
+	const (
+		DefaultValue = 1
+		Key          = "KEY"
+		Value        = 10
+	)
+
+	for _, tc := range []struct {
+		name          string // required
+		key           string
+		value         int
+		defaultValue  int
+		expectedValue int
+	}{
+		{
+			name: "simple",
+		},
+		{
+			name:          "with default value",
+			defaultValue:  DefaultValue,
+			expectedValue: DefaultValue,
+		},
+		{
+			name:          "with actual value",
+			key:           Key,
+			value:         Value,
+			defaultValue:  DefaultValue,
+			expectedValue: Value,
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.key != "" {
+				tc.key = fmt.Sprintf("TEST_%d_%s", rand.Intn(256), tc.key) // #nosec G404
+
+				t.Setenv(tc.key, fmt.Sprint(tc.value))
+			}
+
+			actual := envflag.Int(tc.key, tc.defaultValue)
+			if actual != tc.expectedValue {
+				t.Errorf("expected: %d, got: %d", tc.expectedValue, actual)
+			}
+		})
+	}
+}

--- a/pkg/observability/metrics/metrics.go
+++ b/pkg/observability/metrics/metrics.go
@@ -22,9 +22,12 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
+
+const meterName = "github.com/linode/linode-cosi-driver/pkg/observability/metrics"
 
 func Setup(ctx context.Context, resource *resource.Resource, protocol string) (_ func(context.Context) error, err error) {
 	var exp sdkmetric.Exporter
@@ -63,4 +66,8 @@ func registerMetricsExporter(res *resource.Resource, exporter sdkmetric.Exporter
 	otel.SetMeterProvider(mp)
 
 	return mp.Shutdown, nil
+}
+
+func Meter() metric.Meter {
+	return otel.Meter(meterName)
 }

--- a/pkg/observability/tracing/tracing.go
+++ b/pkg/observability/tracing/tracing.go
@@ -79,8 +79,10 @@ func Start(ctx context.Context, name string) (context.Context, trace.Span) {
 // Error returns an error representing code and error message and records new event on the span.
 // If code is OK, returns nil.
 func Error(span trace.Span, code grpccodes.Code, err error, events ...string) error {
-	for _, event := range events {
-		span.AddEvent(event)
+	if span != nil {
+		for _, event := range events {
+			span.AddEvent(event)
+		}
 	}
 
 	if err != nil && span != nil {

--- a/pkg/observability/tracing/tracing.go
+++ b/pkg/observability/tracing/tracing.go
@@ -20,12 +20,18 @@ import (
 
 	o11y "github.com/linode/linode-cosi-driver/pkg/observability"
 	"go.opentelemetry.io/otel"
+	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+const tracerName = "github.com/linode/linode-cosi-driver/pkg/observability/tracing"
 
 func Setup(ctx context.Context, resource *resource.Resource, protocol string) (_ func(context.Context) error, err error) {
 	var exp sdktrace.SpanExporter
@@ -64,4 +70,26 @@ func registerTraceExporter(res *resource.Resource, exporter sdktrace.SpanExporte
 
 	// Shutdown will flush any remaining spans and shut down the exporter.
 	return tp.Shutdown, nil
+}
+
+func Start(ctx context.Context, name string) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, name)
+}
+
+// Error returns an error representing code and error message and records new event on the span.
+// If code is OK, returns nil.
+func Error(span trace.Span, code grpccodes.Code, err error, events ...string) error {
+	for _, event := range events {
+		span.AddEvent(event)
+	}
+
+	if err != nil && span != nil {
+		span.RecordError(err)
+
+		if code != grpccodes.OK {
+			span.SetStatus(otelcodes.Error, err.Error())
+		}
+	}
+
+	return status.Error(code, fmt.Sprintf("%v", err))
 }

--- a/pkg/servers/identity/metrics.go
+++ b/pkg/servers/identity/metrics.go
@@ -14,11 +14,7 @@
 
 package identity
 
-import (
-	"go.opentelemetry.io/otel"
-)
-
-const meterName = "linode/linode-cosi-driver/servers/identity"
+import "github.com/linode/linode-cosi-driver/pkg/observability/metrics"
 
 // registerMetrics is the common place of registering new metrics to the server.
 // When creating new metrics from the meter1, we call something like:
@@ -27,7 +23,7 @@ const meterName = "linode/linode-cosi-driver/servers/identity"
 //
 // As we expect the metrics to be registered, it is important to return and handle the error.
 func (s *Server) registerMetrics() error {
-	_ = otel.Meter(meterName)
+	_ = metrics.Meter()
 
 	// TODO: any new metrics should be placed here.
 

--- a/pkg/servers/provisioner/consts.go
+++ b/pkg/servers/provisioner/consts.go
@@ -14,20 +14,42 @@
 
 package provisioner
 
-const (
-	ParamRegion = "cosi.linode.com/v1/region"
-	ParamACL    = "cosi.linode.com/v1/acl"
-	ParamCORS   = "cosi.linode.com/v1/cors"
+import (
+	"errors"
+	"net/http"
 
-	ParamCORSValueEnabled  ParamCORSValue = "enabled"
-	ParamCORSValueDisabled ParamCORSValue = "disabled"
+	"github.com/linode/linodego"
+)
+
+const (
+	ParamRegion      = "cosi.linode.com/v1/region"
+	ParamACL         = "cosi.linode.com/v1/acl"
+	ParamCORS        = "cosi.linode.com/v1/cors"
+	ParamPermissions = "cosi.linode.com/v1/permissions"
 )
 
 type ParamCORSValue string
 
+const (
+	ParamCORSValueEnabled  ParamCORSValue = "enabled"
+	ParamCORSValueDisabled ParamCORSValue = "disabled"
+)
+
 func (v ParamCORSValue) Bool() bool {
 	return v == ParamCORSValueEnabled
 }
+
+func (v ParamCORSValue) BoolP() *bool {
+	p := v == ParamCORSValueEnabled
+	return &p
+}
+
+type ParamPermissionsValue string
+
+const (
+	ParamPermissionsValueReadOnly  ParamPermissionsValue = "read_only"
+	ParamPermissionsValueReadWrite ParamPermissionsValue = "read_write"
+)
 
 const (
 	S3                      = "s3"
@@ -35,4 +57,25 @@ const (
 	S3Endpoint              = "endpoint"
 	S3SecretAccessKeyID     = "accessKeyID"
 	S3SecretAccessSecretKey = "accessSecretKey"
+)
+
+var (
+	ErrNotFound            = linodego.Error{Code: http.StatusNotFound}
+	ErrBucketExists        = errors.New("bucket exists with different parameters")
+	ErrUnsuportedAuth      = errors.New("unsupported authentication schema")
+	ErrUnknownPermsissions = errors.New("unknown permissions")
+)
+
+const (
+	KeyBucketID                = "bucket.id"
+	KeyBucketLabel             = "bucket.label"
+	KeyBucketCluster           = "bucket.cluster"
+	KeyBucketCreationTimestamp = "bucket.created_at"
+	KeyBucketACL               = "bucket.acl"
+	KeyBucketCORS              = "bucket.cors_enabled"
+	KeyBucketAccessIDRaw       = "bucket.access.id_raw"
+	KeyBucketAccessID          = "bucket.access.id"
+	KeyBucketAccessName        = "bucket.access.name"
+	KeyBucketAccessAuth        = "bucket.access.auth"
+	KeyBucketAccessPermissions = "bucket.access.permissions"
 )

--- a/pkg/servers/provisioner/consts.go
+++ b/pkg/servers/provisioner/consts.go
@@ -63,6 +63,7 @@ var (
 	ErrNotFound            = linodego.Error{Code: http.StatusNotFound}
 	ErrBucketExists        = errors.New("bucket exists with different parameters")
 	ErrUnsuportedAuth      = errors.New("unsupported authentication schema")
+	ErrMissingRegion       = errors.New("region was not provided")
 	ErrUnknownPermsissions = errors.New("unknown permissions")
 )
 

--- a/pkg/servers/provisioner/consts.go
+++ b/pkg/servers/provisioner/consts.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Akamai Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+const (
+	ParamRegion = "cosi.linode.com/v1/region"
+	ParamACL    = "cosi.linode.com/v1/acl"
+	ParamCORS   = "cosi.linode.com/v1/cors"
+
+	ParamCORSValueEnabled  ParamCORSValue = "enabled"
+	ParamCORSValueDisabled ParamCORSValue = "disabled"
+)
+
+type ParamCORSValue string
+
+func (v ParamCORSValue) Bool() bool {
+	return v == ParamCORSValueEnabled
+}
+
+const (
+	S3                      = "s3"
+	S3Region                = "region"
+	S3Endpoint              = "endpoint"
+	S3SecretAccessKeyID     = "accessKeyID"
+	S3SecretAccessSecretKey = "accessSecretKey"
+)

--- a/pkg/servers/provisioner/metrics.go
+++ b/pkg/servers/provisioner/metrics.go
@@ -14,11 +14,7 @@
 
 package provisioner
 
-import (
-	"go.opentelemetry.io/otel"
-)
-
-const meterName = "linode/linode-cosi-driver/servers/provisioner"
+import "github.com/linode/linode-cosi-driver/pkg/observability/metrics"
 
 // registerMetrics is the common place of registering new metrics to the server.
 // When creating new metrics from the meter1, we call something like:
@@ -27,7 +23,7 @@ const meterName = "linode/linode-cosi-driver/servers/provisioner"
 //
 // As we expect the metrics to be registered, it is important to return and handle the error.
 func (s *Server) registerMetrics() error {
-	_ = otel.Meter(meterName)
+	_ = metrics.Meter()
 
 	// TODO: any new metrics should be placed here.
 

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -16,10 +16,18 @@ package provisioner
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 
 	"github.com/linode/linode-cosi-driver/pkg/linodeclient"
+	"github.com/linode/linode-cosi-driver/pkg/observability/tracing"
+	"github.com/linode/linodego"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
 	cosi "sigs.k8s.io/container-object-storage-interface-spec"
 )
 
@@ -44,11 +52,19 @@ func New(logger *slog.Logger, client linodeclient.Client) (*Server, error) {
 	return srv, srv.registerMetrics()
 }
 
-// init exists in case someone initializes server with nil logger.
-func (s *Server) init() {
-	if s.log == nil {
-		s.log = slog.Default()
-	}
+// init checks if logger was initialized and starts new span.
+func (s *Server) init(ctx context.Context, caller string) (context.Context, trace.Span) {
+	s.once.Do(func() {
+		if s.log == nil {
+			s.log = slog.Default()
+		}
+	})
+
+	return tracing.Start(ctx, caller)
+}
+
+func (s *Server) logAttr(attr ...slog.Attr) *slog.Logger {
+	return slog.New(s.log.Handler().WithAttrs(attr))
 }
 
 // DriverCreateBucket call is made to create the bucket in the backend.
@@ -56,33 +72,118 @@ func (s *Server) init() {
 // NOTE: this call needs to be idempotent.
 //  1. If a bucket that matches both name and parameters already exists, then OK (success) must be returned.
 //  2. If a bucket by same name, but different parameters is provided, then the appropriate error code ALREADY_EXISTS must be returned.
-func (s *Server) DriverCreateBucket(_ context.Context, _ *cosi.DriverCreateBucketRequest) (*cosi.DriverCreateBucketResponse, error) {
-	s.once.Do(s.init)
+func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateBucketRequest) (*cosi.DriverCreateBucketResponse, error) {
+	ctx, span := s.init(ctx, "DriverCreateBucket")
+	defer span.End()
 
-	// get bucket
-	// bucket exists:
-	//    compare actual with expected
-	//    return as in 2
-	// bucket not exists:
-	//    create bucket
-	//    return as in 1
+	label := req.GetName()
+	cluster := req.GetParameters()[ParamRegion]
+	cors := ParamCORSValue(req.GetParameters()[ParamCORS])
 
-	panic("FIXME: unimplemented")
+	acl := linodego.ObjectStorageACL(req.GetParameters()[ParamACL])
+	if acl == "" {
+		acl = linodego.ACLPrivate
+	}
+
+	log := s.logAttr(
+		slog.String(KeyBucketCluster, cluster),
+		slog.String(KeyBucketLabel, label),
+	).WithGroup("DriverCreateBucket")
+
+	span.SetAttributes(
+		attribute.String(KeyBucketCluster, cluster),
+		attribute.String(KeyBucketLabel, label),
+	)
+
+	log.InfoContext(ctx, "bucket creation initiated")
+
+	bucket, err := s.client.GetObjectStorageBucket(ctx, cluster, label)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		log.ErrorContext(ctx, "failed to check if bucket exists", "error", err)
+		return nil, tracing.Error(span, codes.Internal, fmt.Errorf("failed to check if bucket exists: %w", err))
+	} else if !errors.Is(err, ErrNotFound) {
+		log.DebugContext(ctx, "bucket found, checking bucket access",
+			KeyBucketCreationTimestamp, bucket.Cluster,
+		)
+
+		access, err := s.client.GetObjectStorageBucketAccess(ctx, cluster, label)
+		if err != nil {
+			log.ErrorContext(ctx, "failed to check bucket access", "error", err)
+			return nil, tracing.Error(span, codes.Internal, fmt.Errorf("failed to check bucket access: %w", err))
+		}
+
+		if access.ACL != acl || access.CorsEnabled != cors.Bool() {
+			log.ErrorContext(ctx, "bucket with different parameters already exists",
+				"existing_"+KeyBucketACL, access.ACL,
+				"existing_"+KeyBucketCORS, access.CorsEnabled,
+			)
+			return nil, tracing.Error(span, codes.AlreadyExists, ErrBucketExists)
+		}
+
+		log.InfoContext(ctx, "bucket exists")
+
+		return &cosi.DriverCreateBucketResponse{
+			BucketId:   bucket.Cluster + "/" + bucket.Label,
+			BucketInfo: bucketInfo(bucket.Cluster),
+		}, tracing.Error(span, codes.OK, nil, "bucket exists")
+	}
+
+	opts := linodego.ObjectStorageBucketCreateOptions{
+		Cluster:     cluster,
+		Label:       label,
+		ACL:         acl,
+		CorsEnabled: cors.BoolP(),
+	}
+
+	log.InfoContext(ctx, "creating bucket")
+
+	bucket, err = s.client.CreateObjectStorageBucket(ctx, opts)
+	if err != nil {
+		log.ErrorContext(ctx, "failed to create bucket", "error", err)
+		return nil, tracing.Error(span, codes.Internal, fmt.Errorf("failed to create bucket: %w", err))
+	}
+
+	log.InfoContext(ctx, "bucket created")
+
+	return &cosi.DriverCreateBucketResponse{
+		BucketId:   bucket.Cluster + "/" + bucket.Label,
+		BucketInfo: bucketInfo(bucket.Cluster),
+	}, tracing.Error(span, codes.OK, nil, "bucket created")
 }
 
 // DriverDeleteBucket call is made to delete the bucket in the backend.
 //
 // NOTE: this call needs to be idempotent.
 // If the bucket has already been deleted, then no error should be returned.
-func (s *Server) DriverDeleteBucket(_ context.Context, _ *cosi.DriverDeleteBucketRequest) (*cosi.DriverDeleteBucketResponse, error) {
-	s.once.Do(s.init)
+func (s *Server) DriverDeleteBucket(ctx context.Context, req *cosi.DriverDeleteBucketRequest) (*cosi.DriverDeleteBucketResponse, error) {
+	ctx, span := s.init(ctx, "DriverDeleteBucket")
+	defer span.End()
 
-	// delete bucket
-	// bucket not found: success
-	// bucket deleted: success
-	// error: return error
+	cluster, label := parseBucketID(req.GetBucketId())
 
-	panic("FIXME: unimplemented")
+	log := s.logAttr(
+		slog.String(KeyBucketID, req.GetBucketId()),
+		slog.String(KeyBucketCluster, cluster),
+		slog.String(KeyBucketLabel, label),
+	).WithGroup("DriverDeleteBucket")
+
+	span.SetAttributes(
+		attribute.String(KeyBucketID, req.GetBucketId()),
+		attribute.String(KeyBucketCluster, cluster),
+		attribute.String(KeyBucketLabel, label),
+	)
+
+	log.InfoContext(ctx, "bucket deletion initiated")
+
+	err := s.client.DeleteObjectStorageBucket(ctx, cluster, label)
+	if err == nil || errors.Is(err, ErrNotFound) {
+		log.InfoContext(ctx, "bucket deleted")
+		return &cosi.DriverDeleteBucketResponse{}, tracing.Error(span, codes.OK, err, "bucket deleted")
+	}
+
+	log.ErrorContext(ctx, "failed to delete bucket", "error", err)
+
+	return nil, tracing.Error(span, codes.Internal, fmt.Errorf("failed to delete bucket: %w", err))
 }
 
 // DriverGrantBucketAccess call grants access to an account.
@@ -91,17 +192,112 @@ func (s *Server) DriverDeleteBucket(_ context.Context, _ *cosi.DriverDeleteBucke
 // NOTE: this call needs to be idempotent.
 // The account_id returned in the response will be used as the unique identifier for deleting this access when calling DriverRevokeBucketAccess.
 // The returned secret does not need to be the same each call to achieve idempotency.
-func (s *Server) DriverGrantBucketAccess(_ context.Context, _ *cosi.DriverGrantBucketAccessRequest) (*cosi.DriverGrantBucketAccessResponse, error) {
-	s.once.Do(s.init)
+func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGrantBucketAccessRequest) (*cosi.DriverGrantBucketAccessResponse, error) {
+	ctx, span := s.init(ctx, "DriverGrantBucketAccess")
+	defer span.End()
 
-	panic("FIXME: unimplemented")
+	cluster, label := parseBucketID(req.GetBucketId())
+	name := req.GetName()
+	auth := req.GetAuthenticationType()
+	perms := ParamPermissionsValue(req.GetParameters()[ParamPermissions])
+
+	if perms == "" {
+		perms = ParamPermissionsValueReadOnly
+	}
+
+	log := s.logAttr(
+		slog.String(KeyBucketID, req.GetBucketId()),
+		slog.String(KeyBucketCluster, cluster),
+		slog.String(KeyBucketLabel, label),
+		slog.String(KeyBucketAccessName, name),
+		slog.Any(KeyBucketAccessAuth, auth),
+		slog.Any(KeyBucketAccessPermissions, perms),
+	).WithGroup("DriverGrantBucketAccess")
+
+	span.SetAttributes(
+		attribute.String(KeyBucketID, req.GetBucketId()),
+		attribute.String(KeyBucketCluster, cluster),
+		attribute.String(KeyBucketLabel, label),
+		attribute.String(KeyBucketAccessName, name),
+		attribute.String(KeyBucketAccessAuth, auth.String()),
+		attribute.String(KeyBucketAccessPermissions, string(perms)),
+	)
+
+	if auth != cosi.AuthenticationType_Key {
+		log.ErrorContext(ctx, "unsupported authentication type")
+
+		return nil, tracing.Error(span, codes.InvalidArgument, fmt.Errorf("%w: %s", ErrUnsuportedAuth, auth.String()))
+	} else if perms != ParamPermissionsValueReadOnly && perms != ParamPermissionsValueReadWrite {
+		log.ErrorContext(ctx, "unknown permissions")
+
+		return nil, tracing.Error(span, codes.InvalidArgument, fmt.Errorf("%w: %s", ErrUnknownPermsissions, auth.String()))
+	}
+
+	opts := linodego.ObjectStorageKeyCreateOptions{
+		Label: name,
+		BucketAccess: &[]linodego.ObjectStorageKeyBucketAccess{
+			{
+				Cluster:     cluster,
+				BucketName:  label,
+				Permissions: string(perms),
+			},
+		},
+	}
+
+	log.InfoContext(ctx, "creating object storage key")
+
+	key, err := s.client.CreateObjectStorageKey(ctx, opts)
+	if err != nil {
+		log.ErrorContext(ctx, "failed to create object storage key", "error", err)
+		return nil, tracing.Error(span, codes.InvalidArgument, fmt.Errorf("failed to create object storage key: %w", err))
+	}
+
+	log.InfoContext(ctx, "object storage key created")
+
+	return &cosi.DriverGrantBucketAccessResponse{
+		AccountId:   key.Label,
+		Credentials: credentials(cluster, label, key.AccessKey, key.SecretKey),
+	}, tracing.Error(span, codes.OK, nil)
 }
 
 // DriverRevokeBucketAccess call revokes all access to a particular bucket from a principal.
 //
 // NOTE: this call needs to be idempotent.
-func (s *Server) DriverRevokeBucketAccess(_ context.Context, _ *cosi.DriverRevokeBucketAccessRequest) (*cosi.DriverRevokeBucketAccessResponse, error) {
-	s.once.Do(s.init)
+func (s *Server) DriverRevokeBucketAccess(ctx context.Context, req *cosi.DriverRevokeBucketAccessRequest) (*cosi.DriverRevokeBucketAccessResponse, error) {
+	ctx, span := s.init(ctx, "DriverRevokeBucketAccess")
+	defer span.End()
 
-	panic("FIXME: unimplemented")
+	cluster, label := parseBucketID(req.GetBucketId())
+	id, err := strconv.Atoi(req.GetAccountId())
+
+	log := s.logAttr(
+		slog.String(KeyBucketID, req.GetBucketId()),
+		slog.String(KeyBucketAccessIDRaw, req.GetBucketId()),
+		slog.String(KeyBucketCluster, cluster),
+		slog.String(KeyBucketLabel, label),
+		slog.Int(KeyBucketAccessID, id),
+	).WithGroup("DriverRevokeBucketAccess")
+
+	span.SetAttributes(
+		attribute.String(KeyBucketID, req.GetBucketId()),
+		attribute.String(KeyBucketAccessIDRaw, req.GetBucketId()),
+		attribute.String(KeyBucketCluster, cluster),
+		attribute.String(KeyBucketLabel, label),
+		attribute.Int(KeyBucketAccessID, id),
+	)
+
+	if err != nil {
+		log.ErrorContext(ctx, "invalid account id", "error", err)
+		return nil, tracing.Error(span, codes.InvalidArgument, fmt.Errorf("account id is invalid: %w", err))
+	}
+
+	err = s.client.DeleteObjectStorageKey(ctx, id)
+	if err == nil || errors.Is(err, ErrNotFound) {
+		log.InfoContext(ctx, "key deleted")
+		return &cosi.DriverRevokeBucketAccessResponse{}, tracing.Error(span, codes.OK, nil, "key deleted")
+	}
+
+	log.ErrorContext(ctx, "failed to delete key", "error", err)
+
+	return nil, tracing.Error(span, codes.Internal, fmt.Errorf("failed to delete key: %w", err))
 }

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -98,7 +98,7 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 	log.InfoContext(ctx, "bucket creation initiated")
 
 	if cluster == "" {
-		log.ErrorContext(ctx, "missing region")
+		log.ErrorContext(ctx, "required parameter was not provided in the request", "error", ErrMissingRegion)
 
 		return nil, tracing.Error(span, codes.InvalidArgument, ErrMissingRegion)
 	}

--- a/pkg/servers/provisioner/provisionerintegration_test.go
+++ b/pkg/servers/provisioner/provisionerintegration_test.go
@@ -1,0 +1,178 @@
+// Copyright 2023 Akamai Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+// +build integration
+
+package provisioner_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/linode/linode-cosi-driver/pkg/envflag"
+	"github.com/linode/linode-cosi-driver/pkg/linodeclient"
+	"github.com/linode/linode-cosi-driver/pkg/servers/provisioner"
+	"github.com/linode/linode-cosi-driver/pkg/testutils"
+	"github.com/linode/linode-cosi-driver/pkg/version"
+	cosi "sigs.k8s.io/container-object-storage-interface-spec"
+)
+
+func idempotentRun(t *testing.T, n int, name string, run func(t *testing.T)) {
+	for i := 0; i < n; i++ {
+		t.Run(fmt.Sprintf("%s_%d", name, i), run)
+	}
+}
+
+func TestHappyPath(t *testing.T) {
+	t.Parallel()
+
+	var (
+		linodeToken      = envflag.String("LINODE_TOKEN", "")
+		linodeURL        = envflag.String("LINODE_API_URL", "")
+		linodeAPIVersion = envflag.String("LINODE_API_VERSION", "")
+		iterations       = envflag.Int("IDEMPOTENCY_ITERATIONS", 2)
+	)
+
+	if linodeToken == "" {
+		t.Errorf("LINODE_TOKEN not set")
+		return
+	}
+
+	client, err := linodeclient.NewLinodeClient(
+		linodeToken,
+		fmt.Sprintf("LinodeCOSI/%s+integration", version.Version),
+		linodeURL,
+		linodeAPIVersion)
+	if err != nil {
+		t.Errorf("failed to create client: %v", err.Error())
+		return
+	}
+
+	srv, err := provisioner.New(slog.Default(), client)
+	if err != nil {
+		t.Errorf("failed to provisioner: %v", err.Error())
+		return
+	}
+
+	suite := suite{
+		server: srv,
+	}
+
+	idempotentRun(t, iterations, "DriverCreateBucket", suite.DriverCreateBucket)
+	idempotentRun(t, iterations, "DriverGrantBucketAccess", suite.DriverGrantBucketAccess)
+	idempotentRun(t, iterations, "DriverRevokeBucketAccess", suite.DriverRevokeBucketAccess)
+	idempotentRun(t, iterations, "DriverDeleteBucket", suite.DriverDeleteBucket)
+}
+
+type suite struct {
+	server *provisioner.Server
+
+	finishedCreateBucket      bool
+	finishedGrantBucketAccess bool
+
+	bucketID  string
+	accountID string
+}
+
+func (s *suite) DriverCreateBucket(t *testing.T) {
+	ctx, cancel := testutils.ContextFromTimeout(context.Background(), t, 30*time.Second)
+	defer cancel()
+
+	req := &cosi.DriverCreateBucketRequest{
+		Name: "integration",
+		Parameters: map[string]string{
+			provisioner.ParamRegion: "us-east-1",
+			provisioner.ParamACL:    "private",
+			provisioner.ParamCORS:   string(provisioner.ParamCORSValueEnabled),
+		},
+	}
+
+	res, err := s.server.DriverCreateBucket(ctx, req)
+	if err != nil {
+		t.Errorf("failed to create bucket: %v", err)
+	} else {
+		s.bucketID = res.GetBucketId()
+		s.finishedCreateBucket = true
+	}
+}
+
+func (s *suite) DriverDeleteBucket(t *testing.T) {
+	ctx, cancel := testutils.ContextFromTimeout(context.Background(), t, 30*time.Second)
+	defer cancel()
+
+	if !s.finishedCreateBucket {
+		t.Errorf("DriverCreateBucket not executed successfully")
+		return
+	}
+
+	req := &cosi.DriverDeleteBucketRequest{
+		BucketId: s.bucketID,
+	}
+
+	_, err := s.server.DriverDeleteBucket(ctx, req)
+	if err != nil {
+		t.Errorf("failed to delete bucket: %v", err)
+	}
+}
+
+func (s *suite) DriverGrantBucketAccess(t *testing.T) {
+	ctx, cancel := testutils.ContextFromTimeout(context.Background(), t, 30*time.Second)
+	defer cancel()
+
+	if !s.finishedCreateBucket {
+		t.Errorf("DriverCreateBucket not executed successfully")
+		return
+	}
+
+	req := &cosi.DriverGrantBucketAccessRequest{
+		BucketId:           s.bucketID,
+		Name:               "integration",
+		AuthenticationType: cosi.AuthenticationType_Key,
+		Parameters: map[string]string{
+			provisioner.ParamPermissions: string(provisioner.ParamPermissionsValueReadWrite),
+		},
+	}
+
+	res, err := s.server.DriverGrantBucketAccess(ctx, req)
+	if err != nil {
+		t.Errorf("failed to grant bucket access: %v", err)
+	} else {
+		s.accountID = res.GetAccountId()
+		s.finishedGrantBucketAccess = true
+	}
+}
+
+func (s *suite) DriverRevokeBucketAccess(t *testing.T) {
+	ctx, cancel := testutils.ContextFromTimeout(context.Background(), t, 30*time.Second)
+	defer cancel()
+
+	if !s.finishedCreateBucket || !s.finishedGrantBucketAccess {
+		t.Errorf("DriverCreateBucket or DriverGrantBucketAccess not executed successfully")
+		return
+	}
+
+	req := &cosi.DriverRevokeBucketAccessRequest{
+		BucketId:  s.bucketID,
+		AccountId: s.accountID,
+	}
+
+	_, err := s.server.DriverRevokeBucketAccess(ctx, req)
+	if err != nil {
+		t.Errorf("failed to revoke bucket access: %v", err)
+	}
+}

--- a/pkg/servers/provisioner/utils.go
+++ b/pkg/servers/provisioner/utils.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Akamai Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+
+	cosi "sigs.k8s.io/container-object-storage-interface-spec"
+)
+
+func parseBucketID(id string) (cluster string, label string) {
+	chunks := 2
+
+	s := strings.SplitN(id, "/", chunks)
+
+	return s[0], s[1]
+}
+
+func bucketInfo(cluster string) *cosi.Protocol {
+	return &cosi.Protocol{
+		Type: &cosi.Protocol_S3{
+			S3: &cosi.S3{
+				Region:           cluster,
+				SignatureVersion: cosi.S3SignatureVersion_S3V4,
+			},
+		},
+	}
+}
+
+func credentials(cluster, label, accessKey, secretKey string) map[string]*cosi.CredentialDetails {
+	return map[string]*cosi.CredentialDetails{
+		S3: {
+			Secrets: map[string]string{
+				S3Region:                cluster,
+				S3Endpoint:              fmt.Sprintf("%s.linodeobjects.com", label),
+				S3SecretAccessKeyID:     accessKey,
+				S3SecretAccessSecretKey: secretKey,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:
This pull request addresses several aspects related to the Linode COSI driver for object storage provisioning. The key changes are outlined below:

1. **Tests:**
   - Added base unit tests for the provisioner.
   - Fixed and extended existing unit tests for improved coverage.
   - Added happy-path integration tests to cover various operations, such as creating a bucket, granting and revoking bucket access, and deleting a bucket.

2. **Feature Addition:**
   - Added server-side calls to add the complete functionality of the provisioner.

3. **Documentation Update:**
   - Updated the README to include basic usage information.

4. **Example Fixes:**
   - Set the correct cluster in the examples for improved clarity.

## Which issue(s) this PR resolves:
N/A

## Special notes for your reviewer:
The integration tests have prerequisites that need to be met before execution. Ensure the Linode account, API token, and other environment variables are correctly set. Additionally, focus on the newly added server-side calls and verify the correctness of the example fixes.

## Additional documentation e.g., enhancement proposals, usage docs, etc.:

Added basic usage documentation located in [README.md](README.md).