### PR TITLE
fix(deps): set toolchain go1.22.2 go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/linode/linode-cosi-driver
 
 go 1.22
 
+toolchain go1.22.2
+
 require (
 	github.com/go-resty/resty/v2 v2.12.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,3 +1,5 @@
 module test
 
-go 1.21
+go 1.22
+
+toolchain go1.22.2


### PR DESCRIPTION
## Description
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
My go can't download toolchain:

```bash
go env
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```
Here is the answer why: https://github.com/golang/go/issues/62278#issuecomment-1693538776

<!--
Usage: `Resolves #<issue number>`, or `Resolves <link to the issue>`.
If PR is about `failing-tests`, please post the related tests in a comment and do not use `Resolves`
-->
Resolves #
