### PR TITLE
fix(security): leaked credentials in logs

### DIFF
--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -60,8 +60,6 @@ func (c *ClientS3) new(region string) (*minio.Client, error) {
 		return nil, fmt.Errorf("failed to get endpoint for region: %s", region)
 	}
 
-	fmt.Println(endpoint, region, c.s3AccessKey, c.s3SecretKey)
-
 	cli, err := minio.New(endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(c.s3AccessKey, c.s3SecretKey, ""),
 		Region: region,


### PR DESCRIPTION
## Description
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
This pull request removes log line leaking S3 credentials to logs.

