### PR TITLE
[fix] Fixed typo in Deployment template for S3 Secret reference

### DIFF
--- a/helm/linode-cosi-driver/templates/Deployment.yaml
+++ b/helm/linode-cosi-driver/templates/Deployment.yaml
@@ -64,7 +64,7 @@ spec:
                 name: {{ include "linode-cosi-driver.secretName" . }}
             {{- if not .Values.s3.ephemeralCredentials }}
             - secretRef:
-                name: {{ include "linode-cosi-driver.s3secretName" . }}
+                name: {{ include "linode-cosi-driver.s3SecretName" . }}
             {{- end }}
           volumeMounts:
             - name: cosi-socket-dir


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, when trying to use a reference to a Secret in `values.s3.secret.ref` when `values.s3.ephemeralCredentials` is set to `false`, the Secret name was not properly introduced into the Deployment template due to a typo.

**Special notes for your reviewer**:

See the template below
https://github.com/linode/linode-cosi-driver/blob/a4fc2b520263ac798367a51082b5b887700431b3/helm/linode-cosi-driver/templates/_helpers.tpl#L114-L116
You will notice the `_helpers.tpl` file has it called `s3SecretName`.

**TODOs**:

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


