### PR TITLE
set specific regions for which the key is supposed to be created

### DIFF
--- a/cmd/linode-cosi-driver/main.go
+++ b/cmd/linode-cosi-driver/main.go
@@ -60,7 +60,7 @@ func main() {
 		cacheTTL               = envflag.Duration("LINODE_OBJECT_STORAGE_ENDPOINT_CACHE_TTL", cache.DefaultTTL)
 		s3SSL                  = envflag.Bool("S3_CLIENT_SSL_ENABLED", true)
 		s3EphemeralCredentials = envflag.Bool("S3_CLIENT_EPHEMERAL_CREDENTIALS", true)
-		s3Regions              = envflag.String("S3_REGIONS", "")
+		s3EphemeralRegions     = envflag.String("S3_CLIENT_EPHEMERAL_CREDENTIALS_REGIONS", "")
 		s3AccessKey            = envflag.String("S3_ACCESS_KEY", "")
 		s3SecretKey            = envflag.String("S3_SECRET_KEY", "")
 	)
@@ -73,7 +73,7 @@ func main() {
 		cacheTTL:               cacheTTL,
 		s3SSL:                  s3SSL,
 		s3EphemeralCredentials: s3EphemeralCredentials,
-		s3Regions:              parseRegions(s3Regions),
+		s3Regions:              parseRegions(s3EphemeralRegions),
 		s3AccessKey:            s3AccessKey,
 		s3SecretKey:            s3SecretKey,
 	},

--- a/helm/linode-cosi-driver/templates/Deployment.yaml
+++ b/helm/linode-cosi-driver/templates/Deployment.yaml
@@ -59,9 +59,9 @@ spec:
               value: "{{ .Values.s3.ephemeralCredentials }}"
             - name: S3_CLIENT_SSL_ENABLED
               value: "{{ .Values.s3.ssl }}"
-            {{- if .Values.s3.regions }}
-            - name: S3_REGIONS
-              value: "{{ .Values.s3.regions }}"
+            {{- if .Values.s3.ephemeralCredentialsRegions }}
+            - name: S3_CLIENT_EPHEMERAL_CREDENTIALS_REGIONS
+              value: "{{ .Values.s3.ephemeralCredentialsRegions | join \",\" }}"
             {{- end }}
           envFrom:
             - secretRef:

--- a/helm/linode-cosi-driver/templates/Deployment.yaml
+++ b/helm/linode-cosi-driver/templates/Deployment.yaml
@@ -59,6 +59,10 @@ spec:
               value: "{{ .Values.s3.ephemeralCredentials }}"
             - name: S3_CLIENT_SSL_ENABLED
               value: "{{ .Values.s3.ssl }}"
+            {{- if .Values.s3.regions }}
+            - name: S3_REGIONS
+              value: "{{ .Values.s3.regions }}"
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "linode-cosi-driver.secretName" . }}

--- a/helm/linode-cosi-driver/values.yaml
+++ b/helm/linode-cosi-driver/values.yaml
@@ -81,9 +81,9 @@ s3:
   # -- Enable or disable SSL in S3 client.
   ssl: true
 
-  # -- Optional comma-separated list of Object Storage regions for ephemeral S3 credentials.
+  # -- Optional list of Object Storage regions for ephemeral S3 credentials.
   # If empty, credentials can be used in all regions.
-  regions: ""
+  ephemeralCredentialsRegions: []
 
   # -- S3 Secret Key. This field is **required** unless secret is created before deployment (see `s3.secret.ref` value)
   # or ephemeral credentials are enabled (see `s3.ephemeralCredentials` value).

--- a/helm/linode-cosi-driver/values.yaml
+++ b/helm/linode-cosi-driver/values.yaml
@@ -81,6 +81,10 @@ s3:
   # -- Enable or disable SSL in S3 client.
   ssl: true
 
+  # -- Optional comma-separated list of Object Storage regions for ephemeral S3 credentials.
+  # If empty, credentials can be used in all regions.
+  regions: ""
+
   # -- S3 Secret Key. This field is **required** unless secret is created before deployment (see `s3.secret.ref` value)
   # or ephemeral credentials are enabled (see `s3.ephemeralCredentials` value).
   secretKey: ""

--- a/pkg/servers/provisioner/provisionerintegration_test.go
+++ b/pkg/servers/provisioner/provisionerintegration_test.go
@@ -64,7 +64,7 @@ func TestHappyPath(t *testing.T) {
 	var (
 		linodeToken = envflag.String("LINODE_TOKEN", "")
 		iterations  = envflag.Int("IDEMPOTENCY_ITERATIONS", 2)
-		s3Regions   = envflag.String("S3_REGIONS", "")
+		s3Regions   = envflag.String("S3_CLIENT_EPHEMERAL_CREDENTIALS_REGIONS", "")
 	)
 
 	if linodeToken == "" {


### PR DESCRIPTION
This PR allows specific regions to be passed so that the ephemeral key is not created for all obj clusters