### PR TITLE
[feat]: add ability to pass endpoint as bucket parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,16 @@ Here’s the updated table with descriptions added:
 | `cosi.linode.com/v1/region` |            | https://techdocs.akamai.com/linode-api/reference/get-object-storage-endpoints                        | **REQUIRED** The region where the object storage bucket will be created.               |
 | `cosi.linode.com/v1/acl`    | `private`  | `private`, `public-read`, `authenticated-read`, `public-read-write`                                  | The access control list (ACL) policy that defines who can read or write to the bucket. |
 | `cosi.linode.com/v1/cors`   | `disabled` | `disabled`, `enabled`                                                                                | Enables or disables Cross-Origin Resource Sharing (CORS) for the bucket.               |
+| `cosi.linode.com/v1/endpoint-type` | first available | `E0`, `E1`, `E2`, `E3`                                                                       | Selects the Object Storage endpoint type used when creating the bucket.                |
+| `cosi.linode.com/v1/endpoint-type-preference` | first available | Comma-separated `E0`, `E1`, `E2`, `E3` values, for example `E3,E1`                 | Selects the first available Object Storage endpoint type for the bucket in preference order. Ignored when `endpoint-type` is set. |
 | `cosi.linode.com/v1/policy` |            | https://techdocs.akamai.com/cloud-computing/docs/define-access-and-permissions-using-bucket-policies | Defines custom bucket policies for fine-grained access control and permissions.        |
 
 ### BucketAccessClass
 
 | Parameter                        | Default     | Values                    | Description                                                                                                             |
 |----------------------------------|-------------|---------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `cosi.linode.com/v1/endpoint-type` | first available | `E0`, `E1`, `E2`, `E3` | Selects which Object Storage endpoint type to return in generated bucket credentials.                                   |
+| `cosi.linode.com/v1/endpoint-type-preference` | first available | Comma-separated `E0`, `E1`, `E2`, `E3` values, for example `E3,E1` | Selects the first available Object Storage endpoint type for generated bucket credentials in preference order. Ignored when `endpoint-type` is set. |
 | `cosi.linode.com/v1/permissions` | `read_only` | `read_only`, `read_write` | Defines the access permissions for the bucket, specifying whether users can only read data or also write to the bucket. |
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -8,14 +8,13 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/linode/linodego v1.64.0
 	github.com/minio/minio-go/v7 v7.0.98
-	github.com/stretchr/testify v1.11.1
 	go.uber.org/automaxprocs v1.6.0
+	go.uber.org/mock v0.6.0
 	google.golang.org/grpc v1.79.3
 	sigs.k8s.io/container-object-storage-interface-spec v0.1.0
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -27,10 +26,8 @@ require (
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/tinylib/msgp v1.6.1 // indirect
-	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
@@ -39,5 +36,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/linodeclient/cache/endpointcache.go
+++ b/pkg/linodeclient/cache/endpointcache.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/linode/linodego"
+
 	"github.com/linode/linode-cosi-driver/pkg/linodeclient"
 )
 
@@ -33,6 +35,15 @@ const (
 
 type Cache interface {
 	Get(key string) (string, bool)
+}
+
+// Key returns the cache key for a region and endpoint type.
+func Key(region string, endpointType linodego.ObjectStorageEndpointType) string {
+	if endpointType == "" {
+		return region
+	}
+
+	return fmt.Sprintf("%s/%s", region, endpointType)
 }
 
 type EndpointCache struct {
@@ -88,9 +99,14 @@ func (c *EndpointCache) Refresh(ctx context.Context) error {
 		return fmt.Errorf("unable to list ObjectStorage endpoints: %w", err)
 	}
 
+	defaults := make(map[string]struct{})
 	for _, ep := range eps {
 		if ep.S3Endpoint != nil {
-			c.Set(ep.Region, *ep.S3Endpoint)
+			c.Set(Key(ep.Region, ep.EndpointType), *ep.S3Endpoint)
+			if _, ok := defaults[ep.Region]; !ok {
+				c.Set(ep.Region, *ep.S3Endpoint)
+				defaults[ep.Region] = struct{}{}
+			}
 		}
 	}
 

--- a/pkg/linodeclient/cache/endpointcache_test.go
+++ b/pkg/linodeclient/cache/endpointcache_test.go
@@ -41,12 +41,14 @@ func TestCache(t *testing.T) {
 		S3Endpoint: ptr("us-test-1.linodeobjects.com"),
 	}
 	testRegion2 := linodego.ObjectStorageEndpoint{
-		Region:     "de-test",
-		S3Endpoint: ptr("de-test-1.linodeobjects.com"),
+		Region:       "de-test",
+		S3Endpoint:   ptr("de-test-1.linodeobjects.com"),
+		EndpointType: linodego.ObjectStorageEndpointE0,
 	}
 	testRegion3 := linodego.ObjectStorageEndpoint{
-		Region:     "pl-test",
-		S3Endpoint: ptr("pl-test-1.linodeobjects.com"),
+		Region:       "pl-test",
+		S3Endpoint:   ptr("pl-test-1.linodeobjects.com"),
+		EndpointType: linodego.ObjectStorageEndpointE1,
 	}
 
 	ctrl := gomock.NewController(t)
@@ -77,6 +79,11 @@ func TestCache(t *testing.T) {
 	}
 
 	s3Endpoint, ok = cache.Get("pl-test")
+	if !ok || s3Endpoint != *testRegion3.S3Endpoint {
+		t.Errorf("expected %s, got %s", *testRegion3.S3Endpoint, s3Endpoint)
+	}
+
+	s3Endpoint, ok = cache.Get(Key("pl-test", linodego.ObjectStorageEndpointE1))
 	if !ok || s3Endpoint != *testRegion3.S3Endpoint {
 		t.Errorf("expected %s, got %s", *testRegion3.S3Endpoint, s3Endpoint)
 	}

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -34,6 +34,7 @@ type Client interface {
 
 type ClientS3 struct {
 	cache       cache.Cache
+	endpoint    string
 	s3AccessKey string
 	s3SecretKey string
 	s3SSL       bool
@@ -54,10 +55,29 @@ func New(
 	}
 }
 
+func NewWithEndpoint(
+	endpoint string,
+	s3AccessKey, s3SecretKey string,
+	s3SSL bool,
+) *ClientS3 {
+	return &ClientS3{
+		endpoint:    endpoint,
+		s3AccessKey: s3AccessKey,
+		s3SecretKey: s3SecretKey,
+		s3SSL:       s3SSL,
+	}
+}
+
 func (c *ClientS3) new(region string) (*minio.Client, error) {
-	endpoint, ok := c.cache.Get(region)
-	if !ok || endpoint == "" {
-		return nil, fmt.Errorf("failed to get endpoint for region: %s", region)
+	endpoint := c.endpoint
+	if endpoint == "" {
+		var ok bool
+		if c.cache != nil {
+			endpoint, ok = c.cache.Get(region)
+		}
+		if !ok || endpoint == "" {
+			return nil, fmt.Errorf("failed to get endpoint for region: %s", region)
+		}
 	}
 
 	cli, err := minio.New(endpoint, &minio.Options{

--- a/pkg/s3/s3_test.go
+++ b/pkg/s3/s3_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Akamai Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s3
+
+import "testing"
+
+func TestNewWithEndpointDoesNotRequireCache(t *testing.T) {
+	t.Parallel()
+
+	client := NewWithEndpoint("selected.example.com", "access-key", "secret-key", true)
+
+	if _, err := client.new("us-ord"); err != nil {
+		t.Fatalf("expected explicit endpoint client creation to succeed: %v", err)
+	}
+}

--- a/pkg/servers/provisioner/consts.go
+++ b/pkg/servers/provisioner/consts.go
@@ -16,9 +16,7 @@ package provisioner
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/linode/linodego"
 )
@@ -70,59 +68,6 @@ const (
 	ParamPermissionsValueReadOnly  ParamPermissionsValue = "read_only"
 	ParamPermissionsValueReadWrite ParamPermissionsValue = "read_write"
 )
-
-func parseEndpointType(params map[string]string) (linodego.ObjectStorageEndpointType, error) {
-	endpointType := linodego.ObjectStorageEndpointType(params[ParamEndpointType])
-	if endpointType == "" {
-		return "", nil
-	}
-
-	switch endpointType {
-	case linodego.ObjectStorageEndpointE0,
-		linodego.ObjectStorageEndpointE1,
-		linodego.ObjectStorageEndpointE2,
-		linodego.ObjectStorageEndpointE3:
-		return endpointType, nil
-	default:
-		return "", fmt.Errorf("%w: %s", ErrUnknownEndpointType, endpointType)
-	}
-}
-
-func parseEndpointTypePreference(params map[string]string) ([]linodego.ObjectStorageEndpointType, error) {
-	if endpointType, err := parseEndpointType(params); err != nil || endpointType != "" {
-		return []linodego.ObjectStorageEndpointType{endpointType}, err
-	}
-
-	value := strings.TrimSpace(params[ParamEndpointTypePreference])
-	if value == "" {
-		return nil, nil
-	}
-
-	parts := strings.Split(value, ",")
-	preferences := make([]linodego.ObjectStorageEndpointType, 0, len(parts))
-	for _, part := range parts {
-		endpointType := linodego.ObjectStorageEndpointType(strings.TrimSpace(part))
-		if endpointType == "" {
-			continue
-		}
-
-		switch endpointType {
-		case linodego.ObjectStorageEndpointE0,
-			linodego.ObjectStorageEndpointE1,
-			linodego.ObjectStorageEndpointE2,
-			linodego.ObjectStorageEndpointE3:
-			preferences = append(preferences, endpointType)
-		default:
-			return nil, fmt.Errorf("%w: %s", ErrUnknownEndpointType, endpointType)
-		}
-	}
-
-	if len(preferences) == 0 {
-		return nil, nil
-	}
-
-	return preferences, nil
-}
 
 const (
 	S3                      = "s3"

--- a/pkg/servers/provisioner/consts.go
+++ b/pkg/servers/provisioner/consts.go
@@ -16,18 +16,22 @@ package provisioner
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/linode/linodego"
 )
 
 const (
-	prefix           = "cosi.linode.com/v1/"
-	ParamACL         = prefix + "acl"
-	ParamCORS        = prefix + "cors"
-	ParamPermissions = prefix + "permissions"
-	ParamPolicy      = prefix + "policy"
-	ParamRegion      = prefix + "region"
+	prefix                      = "cosi.linode.com/v1/"
+	ParamACL                    = prefix + "acl"
+	ParamCORS                   = prefix + "cors"
+	ParamEndpointType           = prefix + "endpoint-type"
+	ParamEndpointTypePreference = prefix + "endpoint-type-preference"
+	ParamPermissions            = prefix + "permissions"
+	ParamPolicy                 = prefix + "policy"
+	ParamRegion                 = prefix + "region"
 )
 
 // TODO(v1alpha2): add the cleanup:
@@ -67,6 +71,59 @@ const (
 	ParamPermissionsValueReadWrite ParamPermissionsValue = "read_write"
 )
 
+func parseEndpointType(params map[string]string) (linodego.ObjectStorageEndpointType, error) {
+	endpointType := linodego.ObjectStorageEndpointType(params[ParamEndpointType])
+	if endpointType == "" {
+		return "", nil
+	}
+
+	switch endpointType {
+	case linodego.ObjectStorageEndpointE0,
+		linodego.ObjectStorageEndpointE1,
+		linodego.ObjectStorageEndpointE2,
+		linodego.ObjectStorageEndpointE3:
+		return endpointType, nil
+	default:
+		return "", fmt.Errorf("%w: %s", ErrUnknownEndpointType, endpointType)
+	}
+}
+
+func parseEndpointTypePreference(params map[string]string) ([]linodego.ObjectStorageEndpointType, error) {
+	if endpointType, err := parseEndpointType(params); err != nil || endpointType != "" {
+		return []linodego.ObjectStorageEndpointType{endpointType}, err
+	}
+
+	value := strings.TrimSpace(params[ParamEndpointTypePreference])
+	if value == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(value, ",")
+	preferences := make([]linodego.ObjectStorageEndpointType, 0, len(parts))
+	for _, part := range parts {
+		endpointType := linodego.ObjectStorageEndpointType(strings.TrimSpace(part))
+		if endpointType == "" {
+			continue
+		}
+
+		switch endpointType {
+		case linodego.ObjectStorageEndpointE0,
+			linodego.ObjectStorageEndpointE1,
+			linodego.ObjectStorageEndpointE2,
+			linodego.ObjectStorageEndpointE3:
+			preferences = append(preferences, endpointType)
+		default:
+			return nil, fmt.Errorf("%w: %s", ErrUnknownEndpointType, endpointType)
+		}
+	}
+
+	if len(preferences) == 0 {
+		return nil, nil
+	}
+
+	return preferences, nil
+}
+
 const (
 	S3                      = "s3"
 	S3Region                = "region"
@@ -79,6 +136,7 @@ var (
 	ErrNotFound            = linodego.Error{Code: http.StatusNotFound}
 	ErrUnsuportedAuth      = errors.New("unsupported authentication schema")
 	ErrMissingRegion       = errors.New("region was not provided")
+	ErrUnknownEndpointType = errors.New("unknown endpoint type")
 	ErrUnknownPermsissions = errors.New("unknown permissions")
 	ErrValidationError     = errors.New("required value cannot be empty")
 )
@@ -90,6 +148,7 @@ const (
 	KeyBucketCreationTimestamp = "bucket.created_at"
 	KeyBucketACL               = "bucket.acl"
 	KeyBucketCORS              = "bucket.cors_enabled"
+	KeyBucketEndpointType      = "bucket.endpoint_type"
 	KeyBucketAccessIDRaw       = "bucket.access.id_raw"
 	KeyBucketAccessID          = "bucket.access.id"
 	KeyBucketAccessName        = "bucket.access.name"

--- a/pkg/servers/provisioner/endpoint_type.go
+++ b/pkg/servers/provisioner/endpoint_type.go
@@ -1,0 +1,75 @@
+// Copyright 2023-2025 Akamai Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/linode/linodego"
+)
+
+func parseEndpointType(params map[string]string) (linodego.ObjectStorageEndpointType, error) {
+	endpointType := linodego.ObjectStorageEndpointType(params[ParamEndpointType])
+	if endpointType == "" {
+		return "", nil
+	}
+
+	switch endpointType {
+	case linodego.ObjectStorageEndpointE0,
+		linodego.ObjectStorageEndpointE1,
+		linodego.ObjectStorageEndpointE2,
+		linodego.ObjectStorageEndpointE3:
+		return endpointType, nil
+	default:
+		return "", fmt.Errorf("%w: %s", ErrUnknownEndpointType, endpointType)
+	}
+}
+
+func parseEndpointTypePreference(params map[string]string) ([]linodego.ObjectStorageEndpointType, error) {
+	if endpointType, err := parseEndpointType(params); err != nil || endpointType != "" {
+		return []linodego.ObjectStorageEndpointType{endpointType}, err
+	}
+
+	value := strings.TrimSpace(params[ParamEndpointTypePreference])
+	if value == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(value, ",")
+	preferences := make([]linodego.ObjectStorageEndpointType, 0, len(parts))
+	for _, part := range parts {
+		endpointType := linodego.ObjectStorageEndpointType(strings.TrimSpace(part))
+		if endpointType == "" {
+			continue
+		}
+
+		switch endpointType {
+		case linodego.ObjectStorageEndpointE0,
+			linodego.ObjectStorageEndpointE1,
+			linodego.ObjectStorageEndpointE2,
+			linodego.ObjectStorageEndpointE3:
+			preferences = append(preferences, endpointType)
+		default:
+			return nil, fmt.Errorf("%w: %s", ErrUnknownEndpointType, endpointType)
+		}
+	}
+
+	if len(preferences) == 0 {
+		return nil, nil
+	}
+
+	return preferences, nil
+}

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -320,6 +320,9 @@ func (s *Server) selectEndpointType(
 	}
 
 	if len(endpointTypes) > 0 {
+		if params[ParamEndpointType] != "" {
+			return "", fmt.Errorf("object storage endpoint type %s is not available for region: %s", endpointTypes[0], region)
+		}
 		return "", fmt.Errorf("no preferred object storage endpoint type is available for region: %s", region)
 	}
 

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -421,6 +421,10 @@ func (s *Server) endpointForBucket(ctx context.Context, region string, bucket *l
 		return bucket.S3Endpoint, nil
 	}
 
+	if endpoint, ok := s.cache.Get(cache.Key(region, bucket.EndpointType)); ok && endpoint != "" {
+		return endpoint, nil
+	}
+
 	endpoint, err := s.endpointForType(ctx, region, bucket.EndpointType)
 	if err != nil {
 		return "", err

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -72,6 +72,16 @@ func (s *Server) s3ClientForBucket(ctx context.Context, region, label string) (s
 		return s.s3cli, func(context.Context) error { return nil }, nil
 	}
 
+	bucket, err := s.client.GetObjectStorageBucket(ctx, region, label)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get bucket for S3 client: %w", err)
+	}
+
+	endpoint, err := s.endpointForBucket(ctx, region, bucket)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve bucket endpoint for S3 client: %w", err)
+	}
+
 	keyLabel := fmt.Sprintf("cosi-bucket-%s", uuid.NewString())
 	opts := linodego.ObjectStorageKeyCreateOptions{
 		Label: keyLabel,
@@ -93,20 +103,28 @@ func (s *Server) s3ClientForBucket(ctx context.Context, region, label string) (s
 		return s.client.DeleteObjectStorageKey(cctx, key.ID)
 	}
 
-	return s3.New(s.cache, key.AccessKey, key.SecretKey, s.s3SSL), cleanup, nil
+	return s3.NewWithEndpoint(endpoint, key.AccessKey, key.SecretKey, s.s3SSL), cleanup, nil
 }
 
-func (s *Server) s3ClientForPolicy(ctx context.Context, region string) (s3.Client, func(context.Context) error, error) {
+func (s *Server) s3ClientForPolicy(
+	ctx context.Context,
+	bucket *linodego.ObjectStorageBucket,
+) (s3.Client, func(context.Context) error, error) {
 	if s.s3cli != nil {
 		return s.s3cli, func(context.Context) error { return nil }, nil
 	}
 
-	key, cleanup, err := linodeclient.NewEphemeralS3Credentials(ctx, s.logAttr(), s.client, region)
+	endpoint, err := s.endpointForBucket(ctx, bucket.Region, bucket)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve bucket endpoint for policy updates: %w", err)
+	}
+
+	key, cleanup, err := linodeclient.NewEphemeralS3Credentials(ctx, s.logAttr(), s.client, bucket.Region)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create object storage key for policy updates: %w", err)
 	}
 
-	return s3.New(s.cache, key.AccessKey, key.SecretKey, s.s3SSL), cleanup, nil
+	return s3.NewWithEndpoint(endpoint, key.AccessKey, key.SecretKey, s.s3SSL), cleanup, nil
 }
 
 func (s *Server) logAttr(attr ...slog.Attr) *slog.Logger {
@@ -230,11 +248,14 @@ func (s *Server) createBucketAndApplyPolicy(
 	}
 
 	log.InfoContext(ctx, "Bucket created")
+	if endpointType != "" && bucket.EndpointType == "" {
+		bucket.EndpointType = endpointType
+	}
 
 	if policy != "" {
 		log.InfoContext(ctx, "Updating policy")
 
-		if err := s.applyBucketPolicy(ctx, log, region, bucket.Label, policy); err != nil {
+		if err := s.applyBucketPolicy(ctx, log, bucket, policy); err != nil {
 			log.ErrorContext(ctx, "Failed to set bucket policy", "error", err)
 			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to set bucket policy: %v", err))
 		}
@@ -277,7 +298,7 @@ func (s *Server) ensureExistingBucket(
 	// Comparing policies is expensive and hard. If every other parameter is equal,
 	// we assume that bucket is valid, and apply policy only when one was provided.
 	if policy != "" {
-		if err := s.applyBucketPolicy(ctx, log, region, label, policy); err != nil {
+		if err := s.applyBucketPolicy(ctx, log, bucket, policy); err != nil {
 			log.ErrorContext(ctx, "Failed to set bucket policy", "error", err)
 			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to set bucket policy: %v", err))
 		}
@@ -465,18 +486,23 @@ func endpointTypeSupportsCORS(endpointType linodego.ObjectStorageEndpointType) b
 		endpointType != linodego.ObjectStorageEndpointE3
 }
 
-func (s *Server) applyBucketPolicy(ctx context.Context, log *slog.Logger, region, label, policy string) error {
+func (s *Server) applyBucketPolicy(
+	ctx context.Context,
+	log *slog.Logger,
+	bucket *linodego.ObjectStorageBucket,
+	policy string,
+) error {
 	if policy == "" {
 		return nil
 	}
 
-	s3cli, cleanup, err := s.s3ClientForPolicy(ctx, region)
+	s3cli, cleanup, err := s.s3ClientForPolicy(ctx, bucket)
 	if err != nil {
 		return err
 	}
 	defer cleanupWithTimeout(ctx, log, cleanup)
 
-	return s3cli.SetBucketPolicy(ctx, region, label, policy)
+	return s3cli.SetBucketPolicy(ctx, bucket.Region, bucket.Label, policy)
 }
 
 // DriverDeleteBucket call is made to delete the bucket in the backend.

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -562,7 +562,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 	endpoint, err := s.endpointForBucket(ctx, region, bucket)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to select endpoint", "error", err)
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	log = log.With(slog.String(KeyBucketEndpointType, string(bucket.EndpointType)))
 

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -158,6 +158,13 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 		return nil, status.Error(codes.InvalidArgument, "region was not provided")
 	}
 
+	endpoint, err := s.selectEndpoint(ctx, region, req.GetParameters())
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to select endpoint", "error", err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	log = log.With(slog.String(KeyBucketEndpointType, string(endpoint.EndpointType)))
+
 	policy, err := s.buildBucketPolicy(policyTemplate, label)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to generate bucket policy", "error", err)
@@ -172,11 +179,11 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 
 	if bucket == nil {
 		// Create the bucket if it doesn't exist, then apply policy if provided.
-		return s.createBucketAndApplyPolicy(ctx, log, region, label, acl, cors, policy)
+		return s.createBucketAndApplyPolicy(ctx, log, region, label, endpoint.EndpointType, acl, cors, policy)
 	}
 
 	// Bucket exists: validate parameters and re-apply policy for idempotency.
-	return s.ensureExistingBucket(ctx, log, region, label, acl, cors, policy)
+	return s.ensureExistingBucket(ctx, log, bucket, region, label, endpoint.EndpointType, acl, cors, policy)
 }
 
 func (s *Server) buildBucketPolicy(policyTemplate, label string) (string, error) {
@@ -192,15 +199,17 @@ func (s *Server) createBucketAndApplyPolicy(
 	ctx context.Context,
 	log *slog.Logger,
 	region, label string,
+	endpointType linodego.ObjectStorageEndpointType,
 	acl linodego.ObjectStorageACL,
 	cors ParamCORSValue,
 	policy string,
 ) (*cosi.DriverCreateBucketResponse, error) {
 	opts := linodego.ObjectStorageBucketCreateOptions{
-		Region:      region,
-		Label:       label,
-		ACL:         acl,
-		CorsEnabled: cors.BoolP(),
+		Region:       region,
+		Label:        label,
+		EndpointType: endpointType,
+		ACL:          acl,
+		CorsEnabled:  cors.BoolP(),
 	}
 
 	log.InfoContext(ctx, "Creating bucket")
@@ -231,7 +240,9 @@ func (s *Server) createBucketAndApplyPolicy(
 func (s *Server) ensureExistingBucket(
 	ctx context.Context,
 	log *slog.Logger,
+	bucket *linodego.ObjectStorageBucket,
 	region, label string,
+	endpointType linodego.ObjectStorageEndpointType,
 	acl linodego.ObjectStorageACL,
 	cors ParamCORSValue,
 	policy string,
@@ -242,8 +253,11 @@ func (s *Server) ensureExistingBucket(
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to check bucket access: %v", err))
 	}
 
-	if access.ACL != acl || access.CorsEnabled != cors.Bool() {
+	if bucket.EndpointType != endpointType ||
+		access.ACL != acl ||
+		access.CorsEnabled != cors.Bool() {
 		log.ErrorContext(ctx, "Bucket with different parameters already exists",
+			"existing_"+KeyBucketEndpointType, bucket.EndpointType,
 			"existing_"+KeyBucketACL, access.ACL,
 			"existing_"+KeyBucketCORS, access.CorsEnabled,
 		)
@@ -266,6 +280,97 @@ func (s *Server) ensureExistingBucket(
 		BucketId:   region + "/" + label,
 		BucketInfo: bucketInfo(region),
 	}, status.Error(codes.OK, "bucket exists")
+}
+
+func (s *Server) selectEndpoint(
+	ctx context.Context,
+	region string,
+	params map[string]string,
+) (linodego.ObjectStorageEndpoint, error) {
+	endpointTypes, err := parseEndpointTypePreference(params)
+	if err != nil {
+		return linodego.ObjectStorageEndpoint{}, err
+	}
+
+	if endpointType := linodego.ObjectStorageEndpointType(params[ParamEndpointType]); endpointType != "" &&
+		!endpointTypeSupportsCORS(endpointType) &&
+		ParamCORSValue(params[ParamCORS]).Bool() {
+		return linodego.ObjectStorageEndpoint{}, fmt.Errorf("endpoint type %s does not support CORS", endpointType)
+	}
+
+	endpoints, err := s.client.ListObjectStorageEndpoints(ctx, nil)
+	if err != nil {
+		return linodego.ObjectStorageEndpoint{}, fmt.Errorf("list object storage endpoints: %w", err)
+	}
+
+	if len(endpointTypes) > 0 {
+		for _, endpointType := range endpointTypes {
+			for _, endpoint := range endpoints {
+				if endpoint.Region != region ||
+					endpoint.S3Endpoint == nil ||
+					*endpoint.S3Endpoint == "" ||
+					!endpointSupportsParams(endpoint, params) {
+					continue
+				}
+
+				if endpoint.EndpointType == endpointType {
+					return endpoint, nil
+				}
+			}
+		}
+
+		return linodego.ObjectStorageEndpoint{}, fmt.Errorf("no preferred object storage endpoint type is available for region: %s", region)
+	}
+
+	for _, endpoint := range endpoints {
+		if endpoint.Region != region ||
+			endpoint.S3Endpoint == nil ||
+			*endpoint.S3Endpoint == "" ||
+			!endpointSupportsParams(endpoint, params) {
+			continue
+		}
+
+		return endpoint, nil
+	}
+
+	return linodego.ObjectStorageEndpoint{}, fmt.Errorf("no object storage endpoint available for region: %s", region)
+}
+
+func (s *Server) endpointForType(
+	ctx context.Context,
+	region string,
+	endpointType linodego.ObjectStorageEndpointType,
+) (linodego.ObjectStorageEndpoint, error) {
+	endpoints, err := s.client.ListObjectStorageEndpoints(ctx, nil)
+	if err != nil {
+		return linodego.ObjectStorageEndpoint{}, fmt.Errorf("list object storage endpoints: %w", err)
+	}
+
+	for _, endpoint := range endpoints {
+		if endpoint.Region != region ||
+			endpoint.S3Endpoint == nil ||
+			*endpoint.S3Endpoint == "" ||
+			endpoint.EndpointType != endpointType {
+			continue
+		}
+
+		return endpoint, nil
+	}
+
+	return linodego.ObjectStorageEndpoint{}, fmt.Errorf("object storage endpoint type %s is not available for region: %s", endpointType, region)
+}
+
+func endpointSupportsParams(endpoint linodego.ObjectStorageEndpoint, params map[string]string) bool {
+	if ParamCORSValue(params[ParamCORS]).Bool() && !endpointTypeSupportsCORS(endpoint.EndpointType) {
+		return false
+	}
+
+	return true
+}
+
+func endpointTypeSupportsCORS(endpointType linodego.ObjectStorageEndpointType) bool {
+	return endpointType != linodego.ObjectStorageEndpointE2 &&
+		endpointType != linodego.ObjectStorageEndpointE3
 }
 
 func (s *Server) applyBucketPolicy(ctx context.Context, log *slog.Logger, region, label, policy string) error {
@@ -360,6 +465,19 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("%v: %s", ErrUnknownPermsissions, perms))
 	}
 
+	bucket, err := s.client.GetObjectStorageBucket(ctx, region, label)
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to get bucket", "error", err)
+		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get bucket: %v", err))
+	}
+
+	endpoint, err := s.endpointForType(ctx, region, bucket.EndpointType)
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to select endpoint", "error", err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	log = log.With(slog.String(KeyBucketEndpointType, string(endpoint.EndpointType)))
+
 	opts := linodego.ObjectStorageKeyCreateOptions{
 		Label: name,
 		BucketAccess: &[]linodego.ObjectStorageKeyBucketAccess{
@@ -381,15 +499,9 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 
 	log.InfoContext(ctx, "Object storage key created")
 
-	endpoint, ok := s.cache.Get(region)
-	if !ok || endpoint == "" {
-		log.ErrorContext(ctx, "Failed to get endpoint for region", "region", region)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get endpoint for region: %v", region))
-	}
-
 	return &cosi.DriverGrantBucketAccessResponse{
 		AccountId:   fmt.Sprintf("%d", key.ID),
-		Credentials: credentials(region, endpoint, label, key.AccessKey, key.SecretKey),
+		Credentials: credentials(region, *endpoint.S3Endpoint, label, key.AccessKey, key.SecretKey),
 	}, status.Error(codes.OK, "bucket access granted")
 }
 

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -311,7 +311,7 @@ func (s *Server) selectEndpointType(
 
 	endpoints, err := s.client.ListObjectStorageEndpoints(ctx, nil)
 	if err != nil {
-		return "", fmt.Errorf("list object storage endpoints: %w", err)
+		return "", status.Error(codes.Internal, fmt.Sprintf("failed to list object storage endpoints: %v", err))
 	}
 
 	endpoint, ok := selectEndpoint(endpoints, region, endpointTypes, params)

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -158,12 +158,14 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 		return nil, status.Error(codes.InvalidArgument, "region was not provided")
 	}
 
-	endpoint, err := s.selectEndpoint(ctx, region, req.GetParameters())
+	endpointType, err := s.selectEndpointType(ctx, region, req.GetParameters())
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to select endpoint", "error", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	log = log.With(slog.String(KeyBucketEndpointType, string(endpoint.EndpointType)))
+	if endpointType != "" {
+		log = log.With(slog.String(KeyBucketEndpointType, string(endpointType)))
+	}
 
 	policy, err := s.buildBucketPolicy(policyTemplate, label)
 	if err != nil {
@@ -179,11 +181,11 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 
 	if bucket == nil {
 		// Create the bucket if it doesn't exist, then apply policy if provided.
-		return s.createBucketAndApplyPolicy(ctx, log, region, label, endpoint.EndpointType, acl, cors, policy)
+		return s.createBucketAndApplyPolicy(ctx, log, region, label, endpointType, acl, cors, policy)
 	}
 
 	// Bucket exists: validate parameters and re-apply policy for idempotency.
-	return s.ensureExistingBucket(ctx, log, bucket, region, label, endpoint.EndpointType, acl, cors, policy)
+	return s.ensureExistingBucket(ctx, log, bucket, region, label, endpointType, acl, cors, policy)
 }
 
 func (s *Server) buildBucketPolicy(policyTemplate, label string) (string, error) {
@@ -205,11 +207,15 @@ func (s *Server) createBucketAndApplyPolicy(
 	policy string,
 ) (*cosi.DriverCreateBucketResponse, error) {
 	opts := linodego.ObjectStorageBucketCreateOptions{
-		Region:       region,
-		Label:        label,
-		EndpointType: endpointType,
-		ACL:          acl,
-		CorsEnabled:  cors.BoolP(),
+		Region: region,
+		Label:  label,
+		ACL:    acl,
+	}
+	if endpointType != "" {
+		opts.EndpointType = endpointType
+	}
+	if cors.Bool() {
+		opts.CorsEnabled = cors.BoolP()
 	}
 
 	log.InfoContext(ctx, "Creating bucket")
@@ -253,7 +259,7 @@ func (s *Server) ensureExistingBucket(
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to check bucket access: %v", err))
 	}
 
-	if bucket.EndpointType != endpointType ||
+	if (endpointType != "" && bucket.EndpointType != endpointType) ||
 		access.ACL != acl ||
 		access.CorsEnabled != cors.Bool() {
 		log.ErrorContext(ctx, "Bucket with different parameters already exists",
@@ -282,58 +288,102 @@ func (s *Server) ensureExistingBucket(
 	}, status.Error(codes.OK, "bucket exists")
 }
 
-func (s *Server) selectEndpoint(
+func (s *Server) selectEndpointType(
 	ctx context.Context,
 	region string,
 	params map[string]string,
-) (linodego.ObjectStorageEndpoint, error) {
+) (linodego.ObjectStorageEndpointType, error) {
 	endpointTypes, err := parseEndpointTypePreference(params)
 	if err != nil {
-		return linodego.ObjectStorageEndpoint{}, err
+		return "", err
 	}
 
-	if endpointType := linodego.ObjectStorageEndpointType(params[ParamEndpointType]); endpointType != "" &&
-		!endpointTypeSupportsCORS(endpointType) &&
-		ParamCORSValue(params[ParamCORS]).Bool() {
-		return linodego.ObjectStorageEndpoint{}, fmt.Errorf("endpoint type %s does not support CORS", endpointType)
+	if err := validateExplicitEndpointTypeParams(params); err != nil {
+		return "", err
+	}
+
+	if len(endpointTypes) == 0 && !corsEnabled(params) {
+		return "", nil
 	}
 
 	endpoints, err := s.client.ListObjectStorageEndpoints(ctx, nil)
 	if err != nil {
-		return linodego.ObjectStorageEndpoint{}, fmt.Errorf("list object storage endpoints: %w", err)
+		return "", fmt.Errorf("list object storage endpoints: %w", err)
+	}
+
+	endpoint, ok := selectEndpoint(endpoints, region, endpointTypes, params)
+	if ok {
+		return endpoint.EndpointType, nil
 	}
 
 	if len(endpointTypes) > 0 {
-		for _, endpointType := range endpointTypes {
-			for _, endpoint := range endpoints {
-				if endpoint.Region != region ||
-					endpoint.S3Endpoint == nil ||
-					*endpoint.S3Endpoint == "" ||
-					!endpointSupportsParams(endpoint, params) {
-					continue
-				}
-
-				if endpoint.EndpointType == endpointType {
-					return endpoint, nil
-				}
-			}
-		}
-
-		return linodego.ObjectStorageEndpoint{}, fmt.Errorf("no preferred object storage endpoint type is available for region: %s", region)
+		return "", fmt.Errorf("no preferred object storage endpoint type is available for region: %s", region)
 	}
 
+	return "", fmt.Errorf("no object storage endpoint available for region: %s", region)
+}
+
+func selectEndpoint(
+	endpoints []linodego.ObjectStorageEndpoint,
+	region string,
+	endpointTypes []linodego.ObjectStorageEndpointType,
+	params map[string]string,
+) (linodego.ObjectStorageEndpoint, bool) {
+	if len(endpointTypes) == 0 {
+		return firstMatchingEndpoint(endpoints, region, params)
+	}
+
+	return firstPreferredEndpoint(endpoints, region, endpointTypes, params)
+}
+
+func firstPreferredEndpoint(
+	endpoints []linodego.ObjectStorageEndpoint,
+	region string,
+	endpointTypes []linodego.ObjectStorageEndpointType,
+	params map[string]string,
+) (linodego.ObjectStorageEndpoint, bool) {
+	for _, endpointType := range endpointTypes {
+		endpoint, ok := firstMatchingEndpointByType(endpoints, region, endpointType, params)
+		if ok {
+			return endpoint, true
+		}
+	}
+
+	return linodego.ObjectStorageEndpoint{}, false
+}
+
+func firstMatchingEndpointByType(
+	endpoints []linodego.ObjectStorageEndpoint,
+	region string,
+	endpointType linodego.ObjectStorageEndpointType,
+	params map[string]string,
+) (linodego.ObjectStorageEndpoint, bool) {
 	for _, endpoint := range endpoints {
-		if endpoint.Region != region ||
-			endpoint.S3Endpoint == nil ||
-			*endpoint.S3Endpoint == "" ||
-			!endpointSupportsParams(endpoint, params) {
+		if endpoint.EndpointType != endpointType ||
+			!endpointMatchesParams(endpoint, region, params) {
 			continue
 		}
 
-		return endpoint, nil
+		return endpoint, true
 	}
 
-	return linodego.ObjectStorageEndpoint{}, fmt.Errorf("no object storage endpoint available for region: %s", region)
+	return linodego.ObjectStorageEndpoint{}, false
+}
+
+func firstMatchingEndpoint(
+	endpoints []linodego.ObjectStorageEndpoint,
+	region string,
+	params map[string]string,
+) (linodego.ObjectStorageEndpoint, bool) {
+	for _, endpoint := range endpoints {
+		if !endpointMatchesParams(endpoint, region, params) {
+			continue
+		}
+
+		return endpoint, true
+	}
+
+	return linodego.ObjectStorageEndpoint{}, false
 }
 
 func (s *Server) endpointForType(
@@ -360,12 +410,44 @@ func (s *Server) endpointForType(
 	return linodego.ObjectStorageEndpoint{}, fmt.Errorf("object storage endpoint type %s is not available for region: %s", endpointType, region)
 }
 
-func endpointSupportsParams(endpoint linodego.ObjectStorageEndpoint, params map[string]string) bool {
-	if ParamCORSValue(params[ParamCORS]).Bool() && !endpointTypeSupportsCORS(endpoint.EndpointType) {
+func (s *Server) endpointForBucket(ctx context.Context, region string, bucket *linodego.ObjectStorageBucket) (string, error) {
+	if bucket.S3Endpoint != "" {
+		return bucket.S3Endpoint, nil
+	}
+
+	endpoint, err := s.endpointForType(ctx, region, bucket.EndpointType)
+	if err != nil {
+		return "", err
+	}
+
+	return *endpoint.S3Endpoint, nil
+}
+
+func endpointMatchesParams(endpoint linodego.ObjectStorageEndpoint, region string, params map[string]string) bool {
+	if endpoint.Region != region ||
+		endpoint.S3Endpoint == nil ||
+		*endpoint.S3Endpoint == "" {
+		return false
+	}
+
+	if corsEnabled(params) && !endpointTypeSupportsCORS(endpoint.EndpointType) {
 		return false
 	}
 
 	return true
+}
+
+func validateExplicitEndpointTypeParams(params map[string]string) error {
+	endpointType := linodego.ObjectStorageEndpointType(params[ParamEndpointType])
+	if endpointType == "" || endpointTypeSupportsCORS(endpointType) || !corsEnabled(params) {
+		return nil
+	}
+
+	return fmt.Errorf("endpoint type %s does not support CORS", endpointType)
+}
+
+func corsEnabled(params map[string]string) bool {
+	return ParamCORSValue(params[ParamCORS]).Bool()
 }
 
 func endpointTypeSupportsCORS(endpointType linodego.ObjectStorageEndpointType) bool {
@@ -471,12 +553,12 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to get bucket: %v", err))
 	}
 
-	endpoint, err := s.endpointForType(ctx, region, bucket.EndpointType)
+	endpoint, err := s.endpointForBucket(ctx, region, bucket)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to select endpoint", "error", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	log = log.With(slog.String(KeyBucketEndpointType, string(endpoint.EndpointType)))
+	log = log.With(slog.String(KeyBucketEndpointType, string(bucket.EndpointType)))
 
 	opts := linodego.ObjectStorageKeyCreateOptions{
 		Label: name,
@@ -501,7 +583,7 @@ func (s *Server) DriverGrantBucketAccess(ctx context.Context, req *cosi.DriverGr
 
 	return &cosi.DriverGrantBucketAccessResponse{
 		AccountId:   fmt.Sprintf("%d", key.ID),
-		Credentials: credentials(region, *endpoint.S3Endpoint, label, key.AccessKey, key.SecretKey),
+		Credentials: credentials(region, endpoint, label, key.AccessKey, key.SecretKey),
 	}, status.Error(codes.OK, "bucket access granted")
 }
 

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -161,6 +161,9 @@ func (s *Server) DriverCreateBucket(ctx context.Context, req *cosi.DriverCreateB
 	endpointType, err := s.selectEndpointType(ctx, region, req.GetParameters())
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to select endpoint", "error", err)
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	if endpointType != "" {

--- a/pkg/servers/provisioner/provisioner_test.go
+++ b/pkg/servers/provisioner/provisioner_test.go
@@ -161,6 +161,46 @@ func expectGetBucket(t *testing.T, mockLinode *mock.MockLinodeClient, endpointTy
 		Times(2)
 }
 
+func expectCreateBucket(
+	t *testing.T,
+	mockLinode *mock.MockLinodeClient,
+	endpointType linodego.ObjectStorageEndpointType,
+	corsEnabled *bool,
+	bucket *linodego.ObjectStorageBucket,
+) {
+	t.Helper()
+
+	mockLinode.EXPECT().
+		CreateObjectStorageBucket(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, opts linodego.ObjectStorageBucketCreateOptions) (*linodego.ObjectStorageBucket, error) {
+			assertCreateBucketOptions(t, opts, endpointType, corsEnabled)
+			return bucket, nil
+		}).
+		Times(1)
+}
+
+func assertCreateBucketOptions(
+	t *testing.T,
+	opts linodego.ObjectStorageBucketCreateOptions,
+	endpointType linodego.ObjectStorageEndpointType,
+	corsEnabled *bool,
+) {
+	t.Helper()
+
+	if opts.EndpointType != endpointType {
+		t.Errorf("expected endpoint type %s, got %s", endpointType, opts.EndpointType)
+	}
+	if corsEnabled == nil {
+		if opts.CorsEnabled != nil {
+			t.Errorf("expected cors_enabled to be omitted")
+		}
+		return
+	}
+	if opts.CorsEnabled == nil || *opts.CorsEnabled != *corsEnabled {
+		t.Errorf("expected cors_enabled to be %t", *corsEnabled)
+	}
+}
+
 func TestDriverCreateBucket(t *testing.T) {
 	t.Parallel()
 
@@ -223,15 +263,7 @@ func TestDriverCreateBucket(t *testing.T) {
 					Return(nil, linodego.Error{Code: http.StatusNotFound}).
 					Times(1)
 				// Second call: CreateObjectStorageBucket creates the bucket
-				mockLinode.EXPECT().
-					CreateObjectStorageBucket(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, opts linodego.ObjectStorageBucketCreateOptions) (*linodego.ObjectStorageBucket, error) {
-						if opts.EndpointType != linodego.ObjectStorageEndpointE0 {
-							t.Errorf("expected endpoint type %s, got %s", linodego.ObjectStorageEndpointE0, opts.EndpointType)
-						}
-						return defaultLinodegoBucket, nil
-					}).
-					Times(1)
+				expectCreateBucket(t, mockLinode, "", nil, defaultLinodegoBucket)
 				// Third call (idempotency): GetObjectStorageBucket returns the bucket
 				mockLinode.EXPECT().
 					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
@@ -283,15 +315,7 @@ func TestDriverCreateBucket(t *testing.T) {
 					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(nil, linodego.Error{Code: http.StatusNotFound}).
 					Times(1)
-				mockLinode.EXPECT().
-					CreateObjectStorageBucket(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, opts linodego.ObjectStorageBucketCreateOptions) (*linodego.ObjectStorageBucket, error) {
-						if opts.EndpointType != linodego.ObjectStorageEndpointE1 {
-							t.Errorf("expected endpoint type %s, got %s", linodego.ObjectStorageEndpointE1, opts.EndpointType)
-						}
-						return e1Bucket, nil
-					}).
-					Times(1)
+				expectCreateBucket(t, mockLinode, linodego.ObjectStorageEndpointE1, nil, e1Bucket)
 				mockLinode.EXPECT().
 					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(e1Bucket, nil).
@@ -341,22 +365,12 @@ func TestDriverCreateBucket(t *testing.T) {
 					ACL:         linodego.ACLPrivate,
 					CorsEnabled: true,
 				}
+				corsEnabled := true
 				mockLinode.EXPECT().
 					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(nil, linodego.Error{Code: http.StatusNotFound}).
 					Times(1)
-				mockLinode.EXPECT().
-					CreateObjectStorageBucket(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, opts linodego.ObjectStorageBucketCreateOptions) (*linodego.ObjectStorageBucket, error) {
-						if opts.EndpointType != linodego.ObjectStorageEndpointE1 {
-							t.Errorf("expected endpoint type %s, got %s", linodego.ObjectStorageEndpointE1, opts.EndpointType)
-						}
-						if opts.CorsEnabled == nil || !*opts.CorsEnabled {
-							t.Errorf("expected cors_enabled to be true")
-						}
-						return e1Bucket, nil
-					}).
-					Times(1)
+				expectCreateBucket(t, mockLinode, linodego.ObjectStorageEndpointE1, &corsEnabled, e1Bucket)
 				mockLinode.EXPECT().
 					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(e1Bucket, nil).

--- a/pkg/servers/provisioner/provisioner_test.go
+++ b/pkg/servers/provisioner/provisioner_test.go
@@ -75,12 +75,15 @@ const (
 )
 
 var (
-	discardLog   = slog.New(slog.DiscardHandler)
-	testEndpoint = "test-region-1.linodeobjects.com"
+	discardLog     = slog.New(slog.DiscardHandler)
+	testEndpoint   = "test-region-1.linodeobjects.com"
+	testEndpointE1 = "test-region-2.linodeobjects.com"
+	testEndpointE3 = "test-region-3.linodeobjects.com"
 
 	defaultLinodegoBucket = &linodego.ObjectStorageBucket{
-		Label:  testBucketName,
-		Region: testRegion,
+		Label:        testBucketName,
+		Region:       testRegion,
+		EndpointType: linodego.ObjectStorageEndpointE0,
 	}
 	defaultLinodegoBucketAccess = &linodego.ObjectStorageBucketAccess{
 		ACL:         linodego.ACLPrivate,
@@ -100,6 +103,16 @@ var (
 		Region:       testRegion,
 		S3Endpoint:   &testEndpoint,
 		EndpointType: linodego.ObjectStorageEndpointE0,
+	}
+	defaultLinodegoEndpointE1 = linodego.ObjectStorageEndpoint{
+		Region:       testRegion,
+		S3Endpoint:   &testEndpointE1,
+		EndpointType: linodego.ObjectStorageEndpointE1,
+	}
+	defaultLinodegoEndpointE3 = linodego.ObjectStorageEndpoint{
+		Region:       testRegion,
+		S3Endpoint:   &testEndpointE3,
+		EndpointType: linodego.ObjectStorageEndpointE3,
 	}
 
 	defaultBucketInfo = &cosi.Protocol{
@@ -121,6 +134,32 @@ var (
 		},
 	}
 )
+
+func credentialsWithEndpoint(endpoint string) map[string]*cosi.CredentialDetails {
+	return map[string]*cosi.CredentialDetails{
+		provisioner.S3: {
+			Secrets: map[string]string{
+				provisioner.S3Region:                testRegion,
+				provisioner.S3Endpoint:              endpoint,
+				provisioner.S3SecretAccessKeyID:     testAccessKey,
+				provisioner.S3SecretAccessSecretKey: testSecretKey,
+			},
+		},
+	}
+}
+
+func expectGetBucket(t *testing.T, mockLinode *mock.MockLinodeClient, endpointType linodego.ObjectStorageEndpointType) {
+	t.Helper()
+
+	mockLinode.EXPECT().
+		GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
+		Return(&linodego.ObjectStorageBucket{
+			Label:        testBucketName,
+			Region:       testRegion,
+			EndpointType: endpointType,
+		}, nil).
+		Times(2)
+}
 
 func TestDriverCreateBucket(t *testing.T) {
 	t.Parallel()
@@ -186,7 +225,12 @@ func TestDriverCreateBucket(t *testing.T) {
 				// Second call: CreateObjectStorageBucket creates the bucket
 				mockLinode.EXPECT().
 					CreateObjectStorageBucket(gomock.Any(), gomock.Any()).
-					Return(defaultLinodegoBucket, nil).
+					DoAndReturn(func(_ context.Context, opts linodego.ObjectStorageBucketCreateOptions) (*linodego.ObjectStorageBucket, error) {
+						if opts.EndpointType != linodego.ObjectStorageEndpointE0 {
+							t.Errorf("expected endpoint type %s, got %s", linodego.ObjectStorageEndpointE0, opts.EndpointType)
+						}
+						return defaultLinodegoBucket, nil
+					}).
 					Times(1)
 				// Third call (idempotency): GetObjectStorageBucket returns the bucket
 				mockLinode.EXPECT().
@@ -202,6 +246,163 @@ func TestDriverCreateBucket(t *testing.T) {
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
+					AnyTimes()
+				return mockLinode
+			},
+		},
+		{
+			testName: "with endpoint type",
+			request: &cosi.DriverCreateBucketRequest{
+				Name: testBucketName,
+				Parameters: map[string]string{
+					provisioner.ParamRegion:       testRegion,
+					provisioner.ParamEndpointType: string(linodego.ObjectStorageEndpointE1),
+				},
+			},
+			expectedResponse: &cosi.DriverCreateBucketResponse{
+				BucketId:   testBucketID,
+				BucketInfo: defaultBucketInfo,
+			},
+			setupMockS3: func(t *testing.T) s3.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockS3 := mock.NewMockS3Client(ctrl)
+				// No S3 calls expected - no policy provided
+				return mockS3
+			},
+			setupMockLinode: func(t *testing.T) linodeclient.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockLinode := mock.NewMockLinodeClient(ctrl)
+				e1Bucket := &linodego.ObjectStorageBucket{
+					Label:        testBucketName,
+					Region:       testRegion,
+					EndpointType: linodego.ObjectStorageEndpointE1,
+				}
+				mockLinode.EXPECT().
+					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
+					Return(nil, linodego.Error{Code: http.StatusNotFound}).
+					Times(1)
+				mockLinode.EXPECT().
+					CreateObjectStorageBucket(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, opts linodego.ObjectStorageBucketCreateOptions) (*linodego.ObjectStorageBucket, error) {
+						if opts.EndpointType != linodego.ObjectStorageEndpointE1 {
+							t.Errorf("expected endpoint type %s, got %s", linodego.ObjectStorageEndpointE1, opts.EndpointType)
+						}
+						return e1Bucket, nil
+					}).
+					Times(1)
+				mockLinode.EXPECT().
+					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
+					Return(e1Bucket, nil).
+					Times(1)
+				mockLinode.EXPECT().
+					GetObjectStorageBucketAccess(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
+					Return(defaultLinodegoBucketAccess, nil).
+					Times(1)
+				mockLinode.EXPECT().
+					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
+					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint, defaultLinodegoEndpointE1}, nil).
+					AnyTimes()
+				return mockLinode
+			},
+		},
+		{
+			testName: "with endpoint type preference and CORS skips unsupported endpoint",
+			request: &cosi.DriverCreateBucketRequest{
+				Name: testBucketName,
+				Parameters: map[string]string{
+					provisioner.ParamRegion:                 testRegion,
+					provisioner.ParamCORS:                   string(provisioner.ParamCORSValueEnabled),
+					provisioner.ParamEndpointTypePreference: string(linodego.ObjectStorageEndpointE3) + "," + string(linodego.ObjectStorageEndpointE1),
+				},
+			},
+			expectedResponse: &cosi.DriverCreateBucketResponse{
+				BucketId:   testBucketID,
+				BucketInfo: defaultBucketInfo,
+			},
+			setupMockS3: func(t *testing.T) s3.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockS3 := mock.NewMockS3Client(ctrl)
+				// No S3 calls expected - no policy provided
+				return mockS3
+			},
+			setupMockLinode: func(t *testing.T) linodeclient.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockLinode := mock.NewMockLinodeClient(ctrl)
+				e1Bucket := &linodego.ObjectStorageBucket{
+					Label:        testBucketName,
+					Region:       testRegion,
+					EndpointType: linodego.ObjectStorageEndpointE1,
+				}
+				corsEnabledAccess := &linodego.ObjectStorageBucketAccess{
+					ACL:         linodego.ACLPrivate,
+					CorsEnabled: true,
+				}
+				mockLinode.EXPECT().
+					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
+					Return(nil, linodego.Error{Code: http.StatusNotFound}).
+					Times(1)
+				mockLinode.EXPECT().
+					CreateObjectStorageBucket(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, opts linodego.ObjectStorageBucketCreateOptions) (*linodego.ObjectStorageBucket, error) {
+						if opts.EndpointType != linodego.ObjectStorageEndpointE1 {
+							t.Errorf("expected endpoint type %s, got %s", linodego.ObjectStorageEndpointE1, opts.EndpointType)
+						}
+						if opts.CorsEnabled == nil || !*opts.CorsEnabled {
+							t.Errorf("expected cors_enabled to be true")
+						}
+						return e1Bucket, nil
+					}).
+					Times(1)
+				mockLinode.EXPECT().
+					GetObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
+					Return(e1Bucket, nil).
+					Times(1)
+				mockLinode.EXPECT().
+					GetObjectStorageBucketAccess(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
+					Return(corsEnabledAccess, nil).
+					Times(1)
+				mockLinode.EXPECT().
+					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
+					Return([]linodego.ObjectStorageEndpoint{
+						defaultLinodegoEndpointE3,
+						defaultLinodegoEndpointE1,
+					}, nil).
+					AnyTimes()
+				return mockLinode
+			},
+		},
+		{
+			testName: "with explicit CORS unsupported endpoint type",
+			request: &cosi.DriverCreateBucketRequest{
+				Name: testBucketName,
+				Parameters: map[string]string{
+					provisioner.ParamRegion:       testRegion,
+					provisioner.ParamCORS:         string(provisioner.ParamCORSValueEnabled),
+					provisioner.ParamEndpointType: string(linodego.ObjectStorageEndpointE3),
+				},
+			},
+			expectedError: status.Error(grpccodes.InvalidArgument, "endpoint type E3 does not support CORS"),
+			setupMockS3: func(t *testing.T) s3.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockS3 := mock.NewMockS3Client(ctrl)
+				// No S3 calls expected - endpoint selection fails first
+				return mockS3
+			},
+			setupMockLinode: func(t *testing.T) linodeclient.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockLinode := mock.NewMockLinodeClient(ctrl)
+				mockLinode.EXPECT().
+					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
+					Return([]linodego.ObjectStorageEndpoint{
+						defaultLinodegoEndpointE3,
+						defaultLinodegoEndpointE1,
+					}, nil).
 					AnyTimes()
 				return mockLinode
 			},
@@ -708,6 +909,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				t.Helper()
 				ctrl := gomock.NewController(t)
 				mockLinode := mock.NewMockLinodeClient(ctrl)
+				expectGetBucket(t, mockLinode, linodego.ObjectStorageEndpointE0)
 				// Both calls: CreateObjectStorageKey creates the key
 				mockLinode.EXPECT().
 					CreateObjectStorageKey(gomock.Any(), gomock.Any()).
@@ -721,6 +923,171 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
+					AnyTimes()
+				return mockLinode
+			},
+		},
+		{
+			testName: "uses bucket endpoint type despite access endpoint type parameter",
+			request: &cosi.DriverGrantBucketAccessRequest{
+				BucketId:           testBucketID,
+				Name:               testBucketAccessName,
+				AuthenticationType: cosi.AuthenticationType_Key,
+				Parameters: map[string]string{
+					provisioner.ParamPermissions:  string(provisioner.ParamPermissionsValueReadOnly),
+					provisioner.ParamEndpointType: string(linodego.ObjectStorageEndpointE1),
+				},
+			},
+			expectedResponse: &cosi.DriverGrantBucketAccessResponse{
+				AccountId:   testBucketAccessID,
+				Credentials: defaultCredentials,
+			},
+			setupMockS3: func(t *testing.T) s3.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockS3 := mock.NewMockS3Client(ctrl)
+				// No S3 calls expected - GrantBucketAccess only uses Linode API
+				return mockS3
+			},
+			setupMockLinode: func(t *testing.T) linodeclient.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockLinode := mock.NewMockLinodeClient(ctrl)
+				expectGetBucket(t, mockLinode, linodego.ObjectStorageEndpointE0)
+				mockLinode.EXPECT().
+					CreateObjectStorageKey(gomock.Any(), gomock.Any()).
+					Return(&linodego.ObjectStorageKey{
+						ID:        0,
+						AccessKey: testAccessKey,
+						SecretKey: testSecretKey,
+					}, nil).
+					Times(2)
+				mockLinode.EXPECT().
+					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
+					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint, defaultLinodegoEndpointE1}, nil).
+					AnyTimes()
+				return mockLinode
+			},
+		},
+		{
+			testName: "with endpoint type preference fallback",
+			request: &cosi.DriverGrantBucketAccessRequest{
+				BucketId:           testBucketID,
+				Name:               testBucketAccessName,
+				AuthenticationType: cosi.AuthenticationType_Key,
+				Parameters: map[string]string{
+					provisioner.ParamPermissions:            string(provisioner.ParamPermissionsValueReadOnly),
+					provisioner.ParamEndpointTypePreference: string(linodego.ObjectStorageEndpointE3) + "," + string(linodego.ObjectStorageEndpointE1),
+				},
+			},
+			expectedResponse: &cosi.DriverGrantBucketAccessResponse{
+				AccountId:   testBucketAccessID,
+				Credentials: credentialsWithEndpoint(testEndpointE1),
+			},
+			setupMockS3: func(t *testing.T) s3.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockS3 := mock.NewMockS3Client(ctrl)
+				// No S3 calls expected - GrantBucketAccess only uses Linode API
+				return mockS3
+			},
+			setupMockLinode: func(t *testing.T) linodeclient.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockLinode := mock.NewMockLinodeClient(ctrl)
+				expectGetBucket(t, mockLinode, linodego.ObjectStorageEndpointE1)
+				mockLinode.EXPECT().
+					CreateObjectStorageKey(gomock.Any(), gomock.Any()).
+					Return(&linodego.ObjectStorageKey{
+						ID:        0,
+						AccessKey: testAccessKey,
+						SecretKey: testSecretKey,
+					}, nil).
+					Times(2)
+				mockLinode.EXPECT().
+					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
+					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint, defaultLinodegoEndpointE1}, nil).
+					AnyTimes()
+				return mockLinode
+			},
+		},
+		{
+			testName: "uses bucket endpoint type despite unavailable access preference",
+			request: &cosi.DriverGrantBucketAccessRequest{
+				BucketId:           testBucketID,
+				Name:               testBucketAccessName,
+				AuthenticationType: cosi.AuthenticationType_Key,
+				Parameters: map[string]string{
+					provisioner.ParamPermissions:            string(provisioner.ParamPermissionsValueReadOnly),
+					provisioner.ParamEndpointTypePreference: string(linodego.ObjectStorageEndpointE3),
+				},
+			},
+			expectedResponse: &cosi.DriverGrantBucketAccessResponse{
+				AccountId:   testBucketAccessID,
+				Credentials: defaultCredentials,
+			},
+			setupMockS3: func(t *testing.T) s3.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockS3 := mock.NewMockS3Client(ctrl)
+				// No S3 calls expected - endpoint selection fails first
+				return mockS3
+			},
+			setupMockLinode: func(t *testing.T) linodeclient.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockLinode := mock.NewMockLinodeClient(ctrl)
+				expectGetBucket(t, mockLinode, linodego.ObjectStorageEndpointE0)
+				mockLinode.EXPECT().
+					CreateObjectStorageKey(gomock.Any(), gomock.Any()).
+					Return(&linodego.ObjectStorageKey{
+						ID:        0,
+						AccessKey: testAccessKey,
+						SecretKey: testSecretKey,
+					}, nil).
+					Times(2)
+				mockLinode.EXPECT().
+					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
+					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint, defaultLinodegoEndpointE3}, nil).
+					AnyTimes()
+				return mockLinode
+			},
+		},
+		{
+			testName: "default endpoint type from endpoints list",
+			request: &cosi.DriverGrantBucketAccessRequest{
+				BucketId:           testBucketID,
+				Name:               testBucketAccessName,
+				AuthenticationType: cosi.AuthenticationType_Key,
+				Parameters:         defaultBucketAccessParameters,
+			},
+			expectedResponse: &cosi.DriverGrantBucketAccessResponse{
+				AccountId:   testBucketAccessID,
+				Credentials: credentialsWithEndpoint(testEndpointE1),
+			},
+			setupMockS3: func(t *testing.T) s3.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockS3 := mock.NewMockS3Client(ctrl)
+				// No S3 calls expected - GrantBucketAccess only uses Linode API
+				return mockS3
+			},
+			setupMockLinode: func(t *testing.T) linodeclient.Client {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockLinode := mock.NewMockLinodeClient(ctrl)
+				expectGetBucket(t, mockLinode, linodego.ObjectStorageEndpointE1)
+				mockLinode.EXPECT().
+					CreateObjectStorageKey(gomock.Any(), gomock.Any()).
+					Return(&linodego.ObjectStorageKey{
+						ID:        0,
+						AccessKey: testAccessKey,
+						SecretKey: testSecretKey,
+					}, nil).
+					Times(2)
+				mockLinode.EXPECT().
+					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
+					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpointE1}, nil).
 					AnyTimes()
 				return mockLinode
 			},

--- a/pkg/servers/provisioner/provisionerintegration_test.go
+++ b/pkg/servers/provisioner/provisionerintegration_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/linode/linodego"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	cosi "sigs.k8s.io/container-object-storage-interface-spec"
@@ -74,7 +75,7 @@ func TestHappyPath(t *testing.T) {
 		return
 	}
 
-	region, err := resolveTestRegion(t.Context(), client, "")
+	region, err := resolveTestRegion(t.Context(), client, "", true)
 	if err != nil {
 		t.Errorf("failed to resolve test region: %v", err)
 		return
@@ -125,7 +126,7 @@ func TestBucketScopedKeyIsolation(t *testing.T) {
 		return
 	}
 
-	region, err = resolveTestRegion(t.Context(), client, region)
+	region, err = resolveTestRegion(t.Context(), client, region, false)
 	if err != nil {
 		t.Errorf("failed to resolve test region: %v", err)
 		return
@@ -155,7 +156,6 @@ func TestBucketScopedKeyIsolation(t *testing.T) {
 			Parameters: map[string]string{
 				provisioner.ParamRegion: region,
 				provisioner.ParamACL:    "private",
-				provisioner.ParamCORS:   string(provisioner.ParamCORSValueEnabled),
 			},
 		}
 		if _, err := srv.DriverCreateBucket(ctx, req); err != nil {
@@ -200,14 +200,13 @@ func TestBucketScopedKeyIsolation(t *testing.T) {
 		}
 	}()
 
-	endpoint, ok := testCache.Get(region)
-	if !ok || endpoint == "" {
-		t.Fatalf("failed to get endpoint for region: %s", region)
-	}
-
 	creds := grantRes.GetCredentials()[provisioner.S3]
 	if creds == nil {
 		t.Fatalf("missing s3 credentials in response")
+	}
+	endpoint := creds.Secrets[provisioner.S3Endpoint]
+	if endpoint == "" {
+		t.Fatalf("missing endpoint in response")
 	}
 	accessKey := creds.Secrets[provisioner.S3SecretAccessKeyID]
 	secretKey := creds.Secrets[provisioner.S3SecretAccessSecretKey]
@@ -246,8 +245,8 @@ func listObjectsErr(ctx context.Context, cli *minio.Client, bucket string) error
 	return nil
 }
 
-func resolveTestRegion(ctx context.Context, client linodeclient.Client, requested string) (string, error) {
-	if requested != "" {
+func resolveTestRegion(ctx context.Context, client linodeclient.Client, requested string, requireCORS bool) (string, error) {
+	if requested != "" && !requireCORS {
 		return requested, nil
 	}
 
@@ -256,13 +255,48 @@ func resolveTestRegion(ctx context.Context, client linodeclient.Client, requeste
 		return "", fmt.Errorf("list object storage endpoints: %w", err)
 	}
 
-	for _, endpoint := range endpoints {
-		if endpoint.Region != "" && endpoint.S3Endpoint != nil && *endpoint.S3Endpoint != "" {
-			return endpoint.Region, nil
+	if requested != "" {
+		if hasCORSEndpoint(endpoints, requested) {
+			return requested, nil
 		}
+
+		return "", fmt.Errorf("requested region %s does not have an object storage endpoint that supports CORS", requested)
+	}
+
+	for _, endpoint := range endpoints {
+		if endpoint.Region == "" || endpoint.S3Endpoint == nil || *endpoint.S3Endpoint == "" {
+			continue
+		}
+		if requireCORS && !endpointTypeSupportsCORS(endpoint.EndpointType) {
+			continue
+		}
+
+		return endpoint.Region, nil
+	}
+
+	if requireCORS {
+		return "", fmt.Errorf("no object storage endpoint with CORS support available")
 	}
 
 	return "", fmt.Errorf("no object storage endpoint with region and S3 endpoint available")
+}
+
+func hasCORSEndpoint(endpoints []linodego.ObjectStorageEndpoint, region string) bool {
+	for _, endpoint := range endpoints {
+		if endpoint.Region == region &&
+			endpoint.S3Endpoint != nil &&
+			*endpoint.S3Endpoint != "" &&
+			endpointTypeSupportsCORS(endpoint.EndpointType) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func endpointTypeSupportsCORS(endpointType linodego.ObjectStorageEndpointType) bool {
+	return endpointType != linodego.ObjectStorageEndpointE2 &&
+		endpointType != linodego.ObjectStorageEndpointE3
 }
 
 type suite struct {


### PR DESCRIPTION
## Summary

Adds endpoint type selection support for Linode Object Storage provisioning through COSI.

This allows callers to provide an endpoint type preference order, such as `E3,E1`, so the COSI driver can choose an Object Storage endpoint type that is valid for the requested region and driver capabilities. LCR uses this through the `cosi.linode.com/v1/endpoint-type-preference` parameter on COSI resources, which lets registry bucket provisioning prefer E3 while falling back to E1 where needed.

## Changes

- Adds support for reading endpoint type preference from COSI parameters.
- Selects a compatible Object Storage endpoint type during bucket/access provisioning.
- Preserves fallback behavior when multiple endpoint types are provided.
- Enables LCR e2e validation against the `select-endpoint-type` COSI driver image tag.

## Why

Registry bucket provisioning can stall when the requested region and endpoint type do not line up with available Object Storage capabilities. Making endpoint type selection explicit lets LCR provision buckets reliably across environments while keeping the desired preference order configurable.

## Validation

- Deployed the COSI driver from the `select-endpoint-type` branch/image.
- Validated LCR COSI provisioning with endpoint type preference set to `E3,E1`.
- Confirmed registry COSI resources become ready and `bucket-creds` is created for Zot storage.