### PR TITLE
[improvement][deps] Bump go to 1.26.7, enable gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,8 +30,7 @@ linters:
     - gochecksumtype
     - gocognit
     - goconst
-    # TODO: enable in gocritic in it's own PR
-#    - gocritic
+    - gocritic
     - goprintffuncname
     - gosec
     - gosmopolitan

--- a/cmd/linode-cosi-driver/main.go
+++ b/cmd/linode-cosi-driver/main.go
@@ -198,8 +198,8 @@ func run(ctx context.Context, log *slog.Logger, opts mainOptions) error {
 
 func grpcServer(ctx context.Context,
 	log *slog.Logger,
-	identity cosi.IdentityServer,
-	provisioner cosi.ProvisionerServer,
+	identityServer cosi.IdentityServer,
+	provisionerServer cosi.ProvisionerServer,
 ) (*grpc.Server, error) {
 	server := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -208,12 +208,12 @@ func grpcServer(ctx context.Context,
 		),
 	)
 
-	if identity == nil || provisioner == nil {
-		return nil, errors.New("provisioner and identity servers cannot be nil")
+	if identityServer == nil || provisionerServer == nil {
+		return nil, errors.New("provisionerServer and identityServer servers cannot be nil")
 	}
 
-	cosi.RegisterIdentityServer(server, identity)
-	cosi.RegisterProvisionerServer(server, provisioner)
+	cosi.RegisterIdentityServer(server, identityServer)
+	cosi.RegisterProvisionerServer(server, provisionerServer)
 
 	return server, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/linode/linode-cosi-driver
 
 go 1.26
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 require (
 	github.com/go-resty/resty/v2 v2.17.2

--- a/mise.lock
+++ b/mise.lock
@@ -171,36 +171,36 @@ url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs
 url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327219"
 
 [[tools.go]]
-version = "1.26.5"
+version = "1.26.7"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
-url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
+checksum = "sha256:5a4ec883379d51ee9ce1040d5e87f8d35e20387574dd8c947feb01eabc3c1b37"
+url = "https://dl.google.com/go/go1.26.7.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-arm64-musl"]
-checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
-url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
+checksum = "sha256:5a4ec883379d51ee9ce1040d5e87f8d35e20387574dd8c947feb01eabc3c1b37"
+url = "https://dl.google.com/go/go1.26.7.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
-url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
+checksum = "sha256:ffb5f8de10c62550dfddab66b36b57030721e0a44a3218e9e1181d7b59f121ca"
+url = "https://dl.google.com/go/go1.26.7.linux-amd64.tar.gz"
 
 [tools.go."platforms.linux-x64-musl"]
-checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
-url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
+checksum = "sha256:ffb5f8de10c62550dfddab66b36b57030721e0a44a3218e9e1181d7b59f121ca"
+url = "https://dl.google.com/go/go1.26.7.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
-url = "https://dl.google.com/go/go1.26.5.darwin-arm64.tar.gz"
+checksum = "sha256:020a1e8224811be75163e920bc77e0926a1390a6aeea19bdcf23f74b9d749f6d"
+url = "https://dl.google.com/go/go1.26.7.darwin-arm64.tar.gz"
 
 [tools.go."platforms.macos-x64"]
-checksum = "sha256:6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
-url = "https://dl.google.com/go/go1.26.5.darwin-amd64.tar.gz"
+checksum = "sha256:92e8b34bff3c89ab16404c595669ac8cb004cc2f676dcbd1f5b87a6b8def3b47"
+url = "https://dl.google.com/go/go1.26.7.darwin-amd64.tar.gz"
 
 [tools.go."platforms.windows-x64"]
-checksum = "sha256:97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
-url = "https://dl.google.com/go/go1.26.5.windows-amd64.zip"
+checksum = "sha256:f4f534a486e4bc3387fa18f08208f2f854b7aaea8a08f2a2d829a914a05abb11"
+url = "https://dl.google.com/go/go1.26.7.windows-amd64.zip"
 
 [[tools."go:github.com/losisin/helm-values-schema-json/v2"]]
 version = "2.4.0"

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@
 minimum_release_age = "7d"
 
 [tools]
-go = "1.26.5"
+go = "1.26.7"
 
 
 # Build, test, lint, and generation tools.

--- a/pkg/envflag/envflag.go
+++ b/pkg/envflag/envflag.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-func String(envKey string, defaultValue string, expectedValues ...string) string {
+func String(envKey, defaultValue string, expectedValues ...string) string {
 	val, ok := os.LookupEnv(envKey)
 	if !ok {
 		val = defaultValue

--- a/pkg/linodeclient/cache/endpointcache.go
+++ b/pkg/linodeclient/cache/endpointcache.go
@@ -47,7 +47,7 @@ func Key(region string, endpointType linodego.ObjectStorageEndpointType) string 
 }
 
 type EndpointCache struct {
-	sync.RWMutex
+	mu sync.RWMutex
 
 	log    *slog.Logger
 	ttl    time.Duration
@@ -76,14 +76,13 @@ func (c *EndpointCache) Start(ctx context.Context) error {
 		c.log.ErrorContext(ctx, "Failed to refresh cache", "error", err)
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-			defer cancel()
-
 			if err := c.Refresh(ctx); err != nil {
 				c.log.ErrorContext(ctx, "Failed to refresh cache", "error", err)
 			}
@@ -113,22 +112,22 @@ func (c *EndpointCache) Refresh(ctx context.Context) error {
 	return nil
 }
 
-func (c *EndpointCache) Insert(iter iter.Seq2[string, string]) {
-	c.Lock()
-	defer c.Unlock()
+func (c *EndpointCache) Insert(iterator iter.Seq2[string, string]) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	maps.Insert(c.data, iter)
+	maps.Insert(c.data, iterator)
 }
 
 func (c *EndpointCache) Set(key, val string) {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.data[key] = val
 }
 
 func (c *EndpointCache) Get(key string) (string, bool) {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	val, ok := c.data[key]
 

--- a/pkg/linodeclient/linodeclient.go
+++ b/pkg/linodeclient/linodeclient.go
@@ -56,7 +56,7 @@ func NewLinodeClient(ua string) (*linodego.Client, error) {
 
 func NewEphemeralS3Credentials(
 	ctx context.Context,
-	slog *slog.Logger,
+	log *slog.Logger,
 	client Client,
 	region string,
 ) (*linodego.ObjectStorageKey, func(context.Context) error, error) {
@@ -65,7 +65,7 @@ func NewEphemeralS3Credentials(
 	}
 
 	keyLabel := fmt.Sprintf("cosi-%s", uuid.New().String())
-	slog.Info(fmt.Sprintf("Generating new ephemeral key: %s", keyLabel))
+	log.Info(fmt.Sprintf("Generating new ephemeral key: %s", keyLabel))
 
 	creds, err := client.CreateObjectStorageKey(ctx, linodego.ObjectStorageKeyCreateOptions{
 		Label:   keyLabel,

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -33,7 +33,7 @@ type Client interface {
 }
 
 type ClientS3 struct {
-	cache       cache.Cache
+	clientCache cache.Cache
 	endpoint    string
 	s3AccessKey string
 	s3SecretKey string
@@ -43,12 +43,12 @@ type ClientS3 struct {
 var _ Client = (*ClientS3)(nil)
 
 func New(
-	cache cache.Cache,
+	clientCache cache.Cache,
 	s3AccessKey, s3SecretKey string,
 	s3SSL bool,
 ) *ClientS3 {
 	return &ClientS3{
-		cache:       cache,
+		clientCache: clientCache,
 		s3AccessKey: s3AccessKey,
 		s3SecretKey: s3SecretKey,
 		s3SSL:       s3SSL,
@@ -72,8 +72,8 @@ func (c *ClientS3) new(region string) (*minio.Client, error) {
 	endpoint := c.endpoint
 	if endpoint == "" {
 		var ok bool
-		if c.cache != nil {
-			endpoint, ok = c.cache.Get(region)
+		if c.clientCache != nil {
+			endpoint, ok = c.clientCache.Get(region)
 		}
 		if !ok || endpoint == "" {
 			return nil, fmt.Errorf("failed to get endpoint for region: %s", region)

--- a/pkg/servers/provisioner/provisioner.go
+++ b/pkg/servers/provisioner/provisioner.go
@@ -39,10 +39,10 @@ type Server struct {
 	log  *slog.Logger
 	once sync.Once
 
-	client linodeclient.Client
-	cache  cache.Cache
-	s3cli  s3.Client
-	s3SSL  bool
+	client      linodeclient.Client
+	serverCache cache.Cache
+	s3cli       s3.Client
+	s3SSL       bool
 }
 
 // Interface guards.
@@ -52,16 +52,16 @@ var _ cosi.ProvisionerServer = (*Server)(nil)
 func New(
 	logger *slog.Logger,
 	client linodeclient.Client,
-	cache cache.Cache,
+	serverCache cache.Cache,
 	s3cli s3.Client,
 	s3SSL bool,
 ) (*Server, error) {
 	srv := &Server{
-		log:    logger,
-		client: client,
-		cache:  cache,
-		s3cli:  s3cli,
-		s3SSL:  s3SSL,
+		log:         logger,
+		client:      client,
+		serverCache: serverCache,
+		s3cli:       s3cli,
+		s3SSL:       s3SSL,
 	}
 
 	return srv, nil
@@ -443,7 +443,7 @@ func (s *Server) endpointForBucket(ctx context.Context, region string, bucket *l
 		return bucket.S3Endpoint, nil
 	}
 
-	if endpoint, ok := s.cache.Get(cache.Key(region, bucket.EndpointType)); ok && endpoint != "" {
+	if endpoint, ok := s.serverCache.Get(cache.Key(region, bucket.EndpointType)); ok && endpoint != "" {
 		return endpoint, nil
 	}
 

--- a/pkg/servers/provisioner/provisioner_test.go
+++ b/pkg/servers/provisioner/provisioner_test.go
@@ -278,7 +278,7 @@ func TestDriverCreateBucket(t *testing.T) {
 					GetObjectStorageBucketAccess(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(defaultLinodegoBucketAccess, nil).
 					Times(1)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -456,7 +456,7 @@ func TestDriverCreateBucket(t *testing.T) {
 					GetObjectStorageBucketAccess(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(defaultLinodegoBucketAccess, nil).
 					Times(2)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -512,7 +512,7 @@ func TestDriverCreateBucket(t *testing.T) {
 					GetObjectStorageBucketAccess(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(defaultLinodegoBucketAccess, nil).
 					Times(1)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -558,7 +558,7 @@ func TestDriverCreateBucket(t *testing.T) {
 					GetObjectStorageBucketAccess(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(defaultLinodegoBucketAccess, nil).
 					Times(2)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -612,7 +612,7 @@ func TestDriverCreateBucket(t *testing.T) {
 					GetObjectStorageBucketAccess(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(defaultLinodegoBucketAccess, nil).
 					Times(1)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -639,7 +639,7 @@ func TestDriverCreateBucket(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mockLinode := mock.NewMockLinodeClient(ctrl)
 				// No Linode calls expected - validation fails before any API operations
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -665,7 +665,7 @@ func TestDriverCreateBucket(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mockLinode := mock.NewMockLinodeClient(ctrl)
 				// No Linode calls expected - validation fails before any API operations
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -685,7 +685,7 @@ func TestDriverCreateBucket(t *testing.T) {
 			linodeCli := tc.setupMockLinode(t)
 			epc := cache.New(discardLog, linodeCli, 0)
 			if err := epc.Refresh(ctx); err != nil {
-				t.Fatalf("failed to refresh cache: %v", err)
+				t.Fatalf("failed to refresh serverCache: %v", err)
 			}
 
 			s3cli := tc.setupMockS3(t)
@@ -769,16 +769,16 @@ func TestDriverCreateBucketWithPolicyTemplate(t *testing.T) {
 		Return(defaultLinodegoBucketAccess, nil).
 		Times(1)
 
-	// ListObjectStorageEndpoints is called to populate cache
+	// ListObjectStorageEndpoints is called to populate serverCache
 	mockLinode.EXPECT().
 		ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 		Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
 		AnyTimes()
 
-	// Create cache and provisioner
+	// Create serverCache and provisioner
 	epc := cache.New(discardLog, mockLinode, 0)
 	if err := epc.Refresh(ctx); err != nil {
-		t.Fatalf("failed to refresh cache: %v", err)
+		t.Fatalf("failed to refresh serverCache: %v", err)
 	}
 
 	srv, err := provisioner.New(nil, mockLinode, epc, mockS3, true)
@@ -882,7 +882,7 @@ func TestDriverDeleteBucket(t *testing.T) {
 					DeleteObjectStorageBucket(gomock.Any(), gomock.Eq(testRegion), gomock.Eq(testBucketName)).
 					Return(nil).
 					Times(2)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -948,7 +948,7 @@ func TestDriverDeleteBucket(t *testing.T) {
 			linodeCli := tc.setupMockLinode(t)
 			epc := cache.New(discardLog, linodeCli, 0)
 			if err := epc.Refresh(ctx); err != nil {
-				t.Fatalf("failed to refresh cache: %v", err)
+				t.Fatalf("failed to refresh serverCache: %v", err)
 			}
 
 			s3cli := tc.setupMockS3(t)
@@ -1012,7 +1012,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 						SecretKey: testSecretKey,
 					}, nil).
 					Times(2)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -1209,7 +1209,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mockLinode := mock.NewMockLinodeClient(ctrl)
 				// No Linode calls expected - validation fails before any API operations
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -1243,7 +1243,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mockLinode := mock.NewMockLinodeClient(ctrl)
 				// No Linode calls expected - validation fails before any API operations
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -1263,7 +1263,7 @@ func TestDriverGrantBucketAccess(t *testing.T) {
 			linodeCli := tc.setupMockLinode(t)
 			epc := cache.New(discardLog, linodeCli, 0)
 			if err := epc.Refresh(ctx); err != nil {
-				t.Fatalf("failed to refresh cache: %v", err)
+				t.Fatalf("failed to refresh serverCache: %v", err)
 			}
 
 			s3cli := tc.setupMockS3(t)
@@ -1322,7 +1322,7 @@ func TestDriverRevokeBucketAccess(t *testing.T) {
 					DeleteObjectStorageKey(gomock.Any(), gomock.Eq(0)).
 					Return(nil).
 					Times(2)
-				// ListObjectStorageEndpoints is called to populate cache
+				// ListObjectStorageEndpoints is called to populate serverCache
 				mockLinode.EXPECT().
 					ListObjectStorageEndpoints(gomock.Any(), gomock.Any()).
 					Return([]linodego.ObjectStorageEndpoint{defaultLinodegoEndpoint}, nil).
@@ -1342,7 +1342,7 @@ func TestDriverRevokeBucketAccess(t *testing.T) {
 			linodeCli := tc.setupMockLinode(t)
 			epc := cache.New(discardLog, linodeCli, 0)
 			if err := epc.Refresh(ctx); err != nil {
-				t.Fatalf("failed to refresh cache: %v", err)
+				t.Fatalf("failed to refresh serverCache: %v", err)
 			}
 
 			s3cli := tc.setupMockS3(t)

--- a/pkg/servers/provisioner/provisionerintegration_test.go
+++ b/pkg/servers/provisioner/provisionerintegration_test.go
@@ -83,7 +83,7 @@ func TestHappyPath(t *testing.T) {
 
 	testCache := cache.New(slog.Default(), client, cache.DefaultTTL)
 	if err := testCache.Refresh(t.Context()); err != nil {
-		t.Errorf("failed to refresh cache: %v", err.Error())
+		t.Errorf("failed to refresh serverCache: %v", err.Error())
 		return
 	}
 
@@ -134,7 +134,7 @@ func TestBucketScopedKeyIsolation(t *testing.T) {
 
 	testCache := cache.New(slog.Default(), client, cache.DefaultTTL)
 	if err := testCache.Refresh(t.Context()); err != nil {
-		t.Errorf("failed to refresh cache: %v", err.Error())
+		t.Errorf("failed to refresh serverCache: %v", err.Error())
 		return
 	}
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -77,6 +77,13 @@
         "k8s.io/**",
         "sigs.k8s.io/**"
       ]
+    },
+    {
+      "description": "Keep the Go version in sync between go.mod and mise.toml.",
+      "matchManagers": ["mise", "gomod"],
+      "matchDepNames": ["go"],
+      "groupName": "go version",
+      "groupSlug": "go-version",
     }
   ]
 }


### PR DESCRIPTION
- Enables the gocritic linter in golangci-lint and addresses the issues identified by the linter.
- Bumps go to the latest patch for 1.26

